### PR TITLE
Release 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-inference-connector</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Inference Connector - Mule 4</name>
 	<description>MuleSoft Inference Connector for integrating LLM Inference APIs into MuleSoft.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-inference-connector</artifactId>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>0.2.3-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Inference Connector - Mule 4</name>
 	<description>MuleSoft Inference Connector for integrating LLM Inference APIs into MuleSoft.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-inference-connector</artifactId>
-    <version>0.2.3-SNAPSHOT</version>
+    <version>0.2.4-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Inference Connector - Mule 4</name>
 	<description>MuleSoft Inference Connector for integrating LLM Inference APIs into MuleSoft.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-inference-connector</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Inference Connector - Mule 4</name>
 	<description>MuleSoft Inference Connector for integrating LLM Inference APIs into MuleSoft.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-inference-connector</artifactId>
-    <version>0.2.4-SNAPSHOT</version>
+    <version>0.2.8-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Inference Connector - Mule 4</name>
 	<description>MuleSoft Inference Connector for integrating LLM Inference APIs into MuleSoft.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-inference-connector</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.12-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Inference Connector - Mule 4</name>
 	<description>MuleSoft Inference Connector for integrating LLM Inference APIs into MuleSoft.</description>

--- a/src/main/java/com/mulesoft/connectors/internal/constants/InferenceConstants.java
+++ b/src/main/java/com/mulesoft/connectors/internal/constants/InferenceConstants.java
@@ -19,6 +19,7 @@ public class InferenceConstants {
   public static final String DEEPINFRA_URL = "https://api.deepinfra.com/v1/openai";
   public static final String PERPLEXITY_URL = "https://api.perplexity.ai";
   public static final String X_AI_URL = "https://api.x.ai/v1";
+  public static final String OPEN_AI_URL = "https://api.openai.com/v1";
 
   // Ressources
   public static final String CHAT_COMPLETIONS = "/chat/completions";

--- a/src/main/java/com/mulesoft/connectors/internal/constants/InferenceConstants.java
+++ b/src/main/java/com/mulesoft/connectors/internal/constants/InferenceConstants.java
@@ -18,6 +18,7 @@ public class InferenceConstants {
   public static final String TOGETHER_URL = "https://api.together.xyz/v1";
   public static final String DEEPINFRA_URL = "https://api.deepinfra.com/v1/openai";
   public static final String PERPLEXITY_URL = "https://api.perplexity.ai";
+  public static final String X_AI_URL = "https://api.x.ai/v1";
 
   // Ressources
   public static final String CHAT_COMPLETIONS = "/chat/completions";

--- a/src/main/java/com/mulesoft/connectors/internal/constants/InferenceConstants.java
+++ b/src/main/java/com/mulesoft/connectors/internal/constants/InferenceConstants.java
@@ -17,6 +17,7 @@ public class InferenceConstants {
   public static final String FIREWORKS_URL = "https://api.fireworks.ai/inference/v1";
   public static final String TOGETHER_URL = "https://api.together.xyz/v1";
   public static final String DEEPINFRA_URL = "https://api.deepinfra.com/v1/openai";
+  public static final String PERPLEXITY_URL = "https://api.perplexity.ai";
 
   // Ressources
   public static final String CHAT_COMPLETIONS = "/chat/completions";

--- a/src/main/java/com/mulesoft/connectors/internal/constants/InferenceConstants.java
+++ b/src/main/java/com/mulesoft/connectors/internal/constants/InferenceConstants.java
@@ -22,13 +22,14 @@ public class InferenceConstants {
   public static final String OPEN_AI_URL = "https://api.openai.com/v1";
   public static final String MISTRAL_AI_URL = "https://api.mistral.ai/v1";
 
-  // Ressources
+  // Resources
   public static final String CHAT_COMPLETIONS = "/chat/completions";
   public static final String CHAT_COMPLETIONS_OLLAMA = "/chat";
   public static final String GENERATION_OLLAMA = "/generate";
 
   // Configuration Parameters
   public static final String MAX_TOKENS = "max_tokens";
+  public static final String MAX_COMPLETION_TOKENS = "max_completion_tokens";
   public static final String TEMPERATURE = "temperature";
   public static final String TOP_P = "top_p";
   

--- a/src/main/java/com/mulesoft/connectors/internal/constants/InferenceConstants.java
+++ b/src/main/java/com/mulesoft/connectors/internal/constants/InferenceConstants.java
@@ -20,6 +20,7 @@ public class InferenceConstants {
   public static final String PERPLEXITY_URL = "https://api.perplexity.ai";
   public static final String X_AI_URL = "https://api.x.ai/v1";
   public static final String OPEN_AI_URL = "https://api.openai.com/v1";
+  public static final String MISTRAL_AI_URL = "https://api.mistral.ai/v1";
 
   // Ressources
   public static final String CHAT_COMPLETIONS = "/chat/completions";

--- a/src/main/java/com/mulesoft/connectors/internal/models/ModelType.java
+++ b/src/main/java/com/mulesoft/connectors/internal/models/ModelType.java
@@ -4,10 +4,10 @@
 package com.mulesoft.connectors.internal.models;
 
 
+import com.mulesoft.connectors.internal.exception.error.ConfigValidationException;
+
 import java.util.Arrays;
 import java.util.stream.Stream;
-
-import com.mulesoft.connectors.internal.exception.error.ConfigValidationException;
 
 public enum ModelType {
        HUGGING_FACE("HUGGING_FACE", getHuggingFaceModelNameStream()),
@@ -20,7 +20,8 @@ public enum ModelType {
        NVIDIA("NVIDIA", getNVidiaModelNameStream()),
        FIREWORKS("FIREWORKS", getFireworksModelNameStream()),
        TOGETHER("TOGETHER", getTOGETHERModelNameStream()),
-       DEEPINFRA("DEEPINFRA", getDEEPINFRAModelNameStream());
+       DEEPINFRA("DEEPINFRA", getDEEPINFRAModelNameStream()),
+       PERPLEXITY("PERPLEXITY", getPERPLEXITYModelNameStream());
 
   private final String value;
   private final Stream<String> modelNameStream;
@@ -87,12 +88,36 @@ public enum ModelType {
     return Arrays.stream(DeepinfraModelName.values()).map(String::valueOf);
   }
 
+  private static Stream<String> getPERPLEXITYModelNameStream() {
+    return Arrays.stream(PerplexityModelName.values()).map(String::valueOf);
+  }
+
 
   public static ModelType fromValue(String value) {
     return Arrays.stream(ModelType.values())
         .filter(langchainLLMType -> langchainLLMType.value.equals(value))
         .findFirst()
         .orElseThrow(() -> new ConfigValidationException("Unsupported LLM Type: " + value));
+  }
+
+  enum PerplexityModelName {
+
+    sonar("sonar"),
+    sonar_pro("sonar-pro"),
+    sonar_reasoning("sonar-reasoning"),
+    sonar_reasoning_pro("sonar-reasoning-pro"),
+    sonar_deep_research("sonar-deep-research");
+
+    private final String value;
+
+    PerplexityModelName(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return this.value;
+    }
   }
 
   enum DeepinfraModelName {

--- a/src/main/java/com/mulesoft/connectors/internal/models/ModelType.java
+++ b/src/main/java/com/mulesoft/connectors/internal/models/ModelType.java
@@ -22,6 +22,7 @@ public enum ModelType {
        TOGETHER("TOGETHER", getTOGETHERModelNameStream()),
        DEEPINFRA("DEEPINFRA", getDEEPINFRAModelNameStream()),
        PERPLEXITY("PERPLEXITY", getPERPLEXITYModelNameStream()),
+       OPENAI("OPENAI", getOpenAIModelNameStream()),
        XAI("XAI", getXAIModelNameStream());
 
   private final String value;
@@ -93,6 +94,10 @@ public enum ModelType {
     return Arrays.stream(PerplexityModelName.values()).map(String::valueOf);
   }
 
+  private static Stream<String> getOpenAIModelNameStream() {
+    return Arrays.stream(OpenAIModelName.values()).map(String::valueOf);
+  }
+
   private static Stream<String> getXAIModelNameStream() {
     return Arrays.stream(XAIModelName.values()).map(String::valueOf);
   }
@@ -121,6 +126,27 @@ public enum ModelType {
       return this.value;
     }
   }
+
+  enum OpenAIModelName {
+
+    gpt_4_5_preview("gpt-4.5-preview"),
+    o1_mini("o1-mini"),
+    chatgpt_4o_latest("chatgpt-4o-latest"),
+    gpt_4o("gpt-4o"),
+    gpt_4o_mini("gpt-4o-mini");
+
+    private final String value;
+
+    OpenAIModelName(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return this.value;
+    }
+  }
+
 
   enum PerplexityModelName {
 

--- a/src/main/java/com/mulesoft/connectors/internal/models/ModelType.java
+++ b/src/main/java/com/mulesoft/connectors/internal/models/ModelType.java
@@ -23,6 +23,7 @@ public enum ModelType {
        DEEPINFRA("DEEPINFRA", getDEEPINFRAModelNameStream()),
        PERPLEXITY("PERPLEXITY", getPERPLEXITYModelNameStream()),
        OPENAI("OPENAI", getOpenAIModelNameStream()),
+       MISTRAL("MISTRAL", getMistralModelNameStream()),
        XAI("XAI", getXAIModelNameStream());
 
   private final String value;
@@ -98,6 +99,10 @@ public enum ModelType {
     return Arrays.stream(OpenAIModelName.values()).map(String::valueOf);
   }
 
+  private static Stream<String> getMistralModelNameStream() {
+    return Arrays.stream(MistralModelName.values()).map(String::valueOf);
+  }
+
   private static Stream<String> getXAIModelNameStream() {
     return Arrays.stream(XAIModelName.values()).map(String::valueOf);
   }
@@ -138,6 +143,26 @@ public enum ModelType {
     private final String value;
 
     OpenAIModelName(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return this.value;
+    }
+  }
+
+  enum MistralModelName {
+
+    mistral_large_latest("mistral-large-latest"),
+    mistral_small_latest("mistral-small-latest"),
+    open_mistral_nemo("open-mistral-nemo"),
+    pixtral_large_latest("pixtral-large-latest"),
+    gpt_4o_mini("gpt-4o-mini");
+
+    private final String value;
+
+    MistralModelName(String value) {
       this.value = value;
     }
 

--- a/src/main/java/com/mulesoft/connectors/internal/models/ModelType.java
+++ b/src/main/java/com/mulesoft/connectors/internal/models/ModelType.java
@@ -157,8 +157,7 @@ public enum ModelType {
     mistral_large_latest("mistral-large-latest"),
     mistral_small_latest("mistral-small-latest"),
     open_mistral_nemo("open-mistral-nemo"),
-    pixtral_large_latest("pixtral-large-latest"),
-    gpt_4o_mini("gpt-4o-mini");
+    pixtral_large_latest("pixtral-large-latest");
 
     private final String value;
 

--- a/src/main/java/com/mulesoft/connectors/internal/models/ModelType.java
+++ b/src/main/java/com/mulesoft/connectors/internal/models/ModelType.java
@@ -21,7 +21,8 @@ public enum ModelType {
        FIREWORKS("FIREWORKS", getFireworksModelNameStream()),
        TOGETHER("TOGETHER", getTOGETHERModelNameStream()),
        DEEPINFRA("DEEPINFRA", getDEEPINFRAModelNameStream()),
-       PERPLEXITY("PERPLEXITY", getPERPLEXITYModelNameStream());
+       PERPLEXITY("PERPLEXITY", getPERPLEXITYModelNameStream()),
+       XAI("XAI", getXAIModelNameStream());
 
   private final String value;
   private final Stream<String> modelNameStream;
@@ -92,12 +93,33 @@ public enum ModelType {
     return Arrays.stream(PerplexityModelName.values()).map(String::valueOf);
   }
 
+  private static Stream<String> getXAIModelNameStream() {
+    return Arrays.stream(XAIModelName.values()).map(String::valueOf);
+  }
+
 
   public static ModelType fromValue(String value) {
     return Arrays.stream(ModelType.values())
         .filter(langchainLLMType -> langchainLLMType.value.equals(value))
         .findFirst()
         .orElseThrow(() -> new ConfigValidationException("Unsupported LLM Type: " + value));
+  }
+
+  enum XAIModelName {
+
+    grok_2_1212("grok-2-1212"),
+    grok_2_vision_1212("grok-2-vision-1212");
+
+    private final String value;
+
+    XAIModelName(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return this.value;
+    }
   }
 
   enum PerplexityModelName {

--- a/src/main/java/com/mulesoft/connectors/internal/operations/InferenceOperations.java
+++ b/src/main/java/com/mulesoft/connectors/internal/operations/InferenceOperations.java
@@ -370,6 +370,8 @@ public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMR
             return new URL(InferenceConstants.X_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
         case "OPENAI":
             return new URL(InferenceConstants.OPEN_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
+        case "MISTRAL":
+            return new URL(InferenceConstants.MISTRAL_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
         default:
             return new URL ("");
         }

--- a/src/main/java/com/mulesoft/connectors/internal/operations/InferenceOperations.java
+++ b/src/main/java/com/mulesoft/connectors/internal/operations/InferenceOperations.java
@@ -368,6 +368,8 @@ public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMR
             return new URL(InferenceConstants.PERPLEXITY_URL + InferenceConstants.CHAT_COMPLETIONS);
         case "XAI":
             return new URL(InferenceConstants.X_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
+        case "OPENAI":
+            return new URL(InferenceConstants.OPEN_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
         default:
             return new URL ("");
         }

--- a/src/main/java/com/mulesoft/connectors/internal/operations/InferenceOperations.java
+++ b/src/main/java/com/mulesoft/connectors/internal/operations/InferenceOperations.java
@@ -366,6 +366,8 @@ public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMR
             return new URL(InferenceConstants.DEEPINFRA_URL + InferenceConstants.CHAT_COMPLETIONS);
         case "PERPLEXITY":
             return new URL(InferenceConstants.PERPLEXITY_URL + InferenceConstants.CHAT_COMPLETIONS);
+        case "XAI":
+            return new URL(InferenceConstants.X_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
         default:
             return new URL ("");
         }

--- a/src/main/java/com/mulesoft/connectors/internal/operations/InferenceOperations.java
+++ b/src/main/java/com/mulesoft/connectors/internal/operations/InferenceOperations.java
@@ -1,15 +1,22 @@
 package com.mulesoft.connectors.internal.operations;
 
-import static com.mulesoft.connectors.internal.helpers.ResponseHelper.createLLMResponse;
+import com.mulesoft.connectors.internal.api.metadata.LLMResponseAttributes;
+import com.mulesoft.connectors.internal.api.metadata.TokenUsage;
+import com.mulesoft.connectors.internal.config.InferenceConfiguration;
 import com.mulesoft.connectors.internal.constants.InferenceConstants;
 import com.mulesoft.connectors.internal.exception.InferenceErrorType;
 import com.mulesoft.connectors.internal.helpers.TokenHelper;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.mule.runtime.extension.api.annotation.Alias;
+import org.mule.runtime.extension.api.annotation.metadata.fixed.OutputJsonType;
+import org.mule.runtime.extension.api.annotation.param.Config;
+import org.mule.runtime.extension.api.annotation.param.Content;
+import org.mule.runtime.extension.api.annotation.param.MediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -17,25 +24,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.mule.runtime.extension.api.annotation.Alias;
-import org.mule.runtime.extension.api.annotation.param.MediaType;
-import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.mulesoft.connectors.internal.api.metadata.LLMResponseAttributes;
-import com.mulesoft.connectors.internal.api.metadata.TokenUsage;
-import com.mulesoft.connectors.internal.config.InferenceConfiguration;
-
+import static com.mulesoft.connectors.internal.helpers.ResponseHelper.createLLMResponse;
 import static org.mule.runtime.extension.api.annotation.param.MediaType.APPLICATION_JSON;
-import org.mule.runtime.extension.api.annotation.metadata.fixed.OutputJsonType;
-
-import org.mule.runtime.extension.api.annotation.param.Config;
-import org.mule.runtime.extension.api.annotation.param.Content;
-
-import static org.apache.commons.io.IOUtils.toInputStream;
 
 
 /**
@@ -374,6 +364,8 @@ public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMR
             return new URL(InferenceConstants.TOGETHER_URL + InferenceConstants.CHAT_COMPLETIONS);
         case "DEEPINFRA": 
             return new URL(InferenceConstants.DEEPINFRA_URL + InferenceConstants.CHAT_COMPLETIONS);
+        case "PERPLEXITY":
+            return new URL(InferenceConstants.PERPLEXITY_URL + InferenceConstants.CHAT_COMPLETIONS);
         default:
             return new URL ("");
         }

--- a/src/main/java/com/mulesoft/connectors/internal/operations/InferenceOperations.java
+++ b/src/main/java/com/mulesoft/connectors/internal/operations/InferenceOperations.java
@@ -13,6 +13,7 @@ import org.mule.runtime.extension.api.annotation.metadata.fixed.OutputJsonType;
 import org.mule.runtime.extension.api.annotation.param.Config;
 import org.mule.runtime.extension.api.annotation.param.Content;
 import org.mule.runtime.extension.api.annotation.param.MediaType;
+import org.mule.runtime.extension.api.exception.ModuleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,447 +25,469 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import static com.mulesoft.connectors.internal.helpers.ResponseHelper.createLLMResponse;
 import static org.mule.runtime.extension.api.annotation.param.MediaType.APPLICATION_JSON;
 
-
 /**
- * This class is a container for operations, every public method in this class will be taken as an extension operation.
+ * This class contains operations for the inference connector.
+ * Each public method represents an extension operation.
  */
 public class InferenceOperations {
-  private static final Logger LOGGER = LoggerFactory.getLogger(InferenceOperations.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(InferenceOperations.class);
+    private static final String[] NO_TEMPERATURE_MODELS = {"o3-mini", "o1", "o1-mini"};
+    private static final String ERROR_MSG_FORMAT = "%s result error";
 
+    /**
+     * Chat completions by messages array including system, users messages i.e. conversation history
+     * @param configuration the connector configuration
+     * @param messages the conversation history as a JSON array
+     * @return result containing the LLM response
+     * @throws ModuleException if an error occurs during the operation
+     */
+    @MediaType(value = APPLICATION_JSON, strict = false)
+    @Alias("Chat-completions")
+    @OutputJsonType(schema = "api/response/Response.json")
+    public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMResponseAttributes> chatCompletion(
+            @Config InferenceConfiguration configuration,
+            @Content InputStream messages) throws ModuleException {
+        try {
+            JSONArray messagesArray = parseInputStreamToJsonArray(messages);
+            URL chatCompUrl = getConnectionURLChatCompletion(configuration);
+            JSONObject payload = buildPayload(configuration, messagesArray, null);
+            String response = executeREST(chatCompUrl, configuration, payload.toString());
 
-/**
- * Chat completions by messages array including system, users messages i.e. conversation history
- * @throws Exception 
-*/
-@MediaType(value = APPLICATION_JSON, strict = false)
-@Alias("Chat-completions")
-@OutputJsonType(schema = "api/response/Response.json")
-public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMResponseAttributes> chatCompletion(
-                            @Config InferenceConfiguration configuration, 
-                            @Content InputStream messages) throws Exception {
-   try {
-      JSONArray messagesArray = getInputString(messages);
-      URL chatCompUrl = getConnectionURLChatCompletion(configuration);
-
-      System.out.println(configuration.getInferenceType());
-      JSONObject payload = getPayload(configuration, messagesArray, null);
-      System.out.println(payload);
-
-      String response = executeREST(chatCompUrl,configuration, payload.toString());
-      System.out.println(response);
-
-      JSONObject root = new JSONObject(response);
-      String model = root.getString("model");      
-      String id = !"OLLAMA".equals(configuration.getInferenceType()) ? root.getString("id") : null;
-      JSONObject message;
-      String finishReason;
-
-      if (!"OLLAMA".equals(configuration.getInferenceType())) {
-        JSONArray choicesArray = root.getJSONArray("choices");
-        JSONObject firstChoice = choicesArray.getJSONObject(0);
-        // aw add/nim finishReason = firstChoice.getString("finish_reason");
-        finishReason = !"NVIDIA".equals(configuration.getInferenceType()) ? firstChoice.getString("finish_reason") : "";
-        message = firstChoice.getJSONObject("message");
-
-      } else {
-        message = root.getJSONObject("message");
-        finishReason = root.getString("done_reason");
-      }
-
-      String content = message.getString("content");
-
-
-      TokenUsage tokenUsage = TokenHelper.parseUsageFromResponse(response);
-      JSONObject jsonObject = new JSONObject();
-      jsonObject.put(InferenceConstants.RESPONSE, content);
-      Map<String, String> responseAttributes = new HashMap<>();;
-      responseAttributes.put(InferenceConstants.FINISH_REASON, finishReason); 
-      responseAttributes.put(InferenceConstants.MODEL, model); 
-      responseAttributes.put(InferenceConstants.ID_STRING, id); 
-
-      LOGGER.debug("Chat completions result {}", response);
-
-      return createLLMResponse(jsonObject.toString(), tokenUsage, responseAttributes);
-     } catch (Exception e) {
-      throw new org.mule.runtime.extension.api.exception.ModuleException("Chat completions result {}", InferenceErrorType.CHAT_COMPLETION, e);
-      //LOGGER.debug("Error in chat completions {}", e.getMessage());
-      //System.out.println(e.getMessage());
-
+            LOGGER.debug("Chat completions result {}", response);
+            return processLLMResponse(response, configuration);
+        } catch (Exception e) {
+            LOGGER.error("Error in chat completions: {}", e.getMessage(), e);
+            throw new ModuleException(String.format(ERROR_MSG_FORMAT, "Chat completions"),
+                    InferenceErrorType.CHAT_COMPLETION, e);
+        }
     }
-  }
 
-/**
- * Simple chat answer prompt
- * @throws Exception 
-*/
-@MediaType(value = APPLICATION_JSON, strict = false)
-@Alias("Chat-answer-prompt")
-@OutputJsonType(schema = "api/response/Response.json")
-public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMResponseAttributes> chatAnswerPrompt(
-                            @Config InferenceConfiguration configuration,
-                            @Content String prompt) throws Exception {
-   try {
-      JSONArray messagesArray = new JSONArray();
-      JSONObject usersPrompt = new JSONObject();
-      usersPrompt.put("role", "user");
-      usersPrompt.put("content", prompt);
-      messagesArray.put(usersPrompt);
+    /**
+     * Simple chat answer for a single prompt
+     * @param configuration the connector configuration
+     * @param prompt the user's prompt
+     * @return result containing the LLM response
+     * @throws ModuleException if an error occurs during the operation
+     */
+    @MediaType(value = APPLICATION_JSON, strict = false)
+    @Alias("Chat-answer-prompt")
+    @OutputJsonType(schema = "api/response/Response.json")
+    public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMResponseAttributes> chatAnswerPrompt(
+            @Config InferenceConfiguration configuration,
+            @Content String prompt) throws ModuleException {
+        try {
+            JSONArray messagesArray = new JSONArray();
+            JSONObject usersPrompt = new JSONObject();
+            usersPrompt.put("role", "user");
+            usersPrompt.put("content", prompt);
+            messagesArray.put(usersPrompt);
 
-      URL chatCompUrl = getConnectionURLChatCompletion(configuration);
+            URL chatCompUrl = getConnectionURLChatCompletion(configuration);
+            JSONObject payload = buildPayload(configuration, messagesArray, null);
+            String response = executeREST(chatCompUrl, configuration, payload.toString());
 
-      JSONObject payload = getPayload(configuration, messagesArray, null);
-
-      String response = executeREST(chatCompUrl,configuration, payload.toString());
-
-
-      JSONObject root = new JSONObject(response);
-      String model = root.getString("model");      
-      String id = !"OLLAMA".equals(configuration.getInferenceType()) ? root.getString("id") : null;
-      JSONObject message;
-      String finishReason;
-
-      if (!"OLLAMA".equals(configuration.getInferenceType())) {
-        JSONArray choicesArray = root.getJSONArray("choices");
-        JSONObject firstChoice = choicesArray.getJSONObject(0);
-        // aw add/nim finishReason = firstChoice.getString("finish_reason");
-        finishReason = !"NVIDIA".equals(configuration.getInferenceType()) ? firstChoice.getString("finish_reason") : "";
-        message = firstChoice.getJSONObject("message");
-
-      } else {
-        message = root.getJSONObject("message");
-        finishReason = root.getString("done_reason");
-      }
-
-      String content = message.getString("content");
-
-      TokenUsage tokenUsage = TokenHelper.parseUsageFromResponse(response);
-      JSONObject jsonObject = new JSONObject();
-      jsonObject.put(InferenceConstants.RESPONSE, content);
-      Map<String, String> responseAttributes = new HashMap<>();;
-      responseAttributes.put(InferenceConstants.FINISH_REASON, finishReason); 
-      responseAttributes.put(InferenceConstants.MODEL, model); 
-      responseAttributes.put(InferenceConstants.ID_STRING, id); 
-
-      LOGGER.debug("Chat answer prompt result {}", response);
-
-      return createLLMResponse(jsonObject.toString(), tokenUsage, responseAttributes);
-     } catch (Exception e) {
-      throw new org.mule.runtime.extension.api.exception.ModuleException("Chat answer prompt result {}", InferenceErrorType.CHAT_COMPLETION, e);
-      //LOGGER.debug("Error in chat completions {}", e.getMessage());
-      //System.out.println(e.getMessage());
-
+            LOGGER.debug("Chat answer prompt result {}", response);
+            return processLLMResponse(response, configuration);
+        } catch (Exception e) {
+            LOGGER.error("Error in chat answer prompt: {}", e.getMessage(), e);
+            throw new ModuleException(String.format(ERROR_MSG_FORMAT, "Chat answer prompt"),
+                    InferenceErrorType.CHAT_COMPLETION, e);
+        }
     }
-  }
 
-/**
- * Define a prompt template
- * @throws Exception 
-*/
-@MediaType(value = APPLICATION_JSON, strict = false)
-@Alias("Agent-define-prompt-template")
-@OutputJsonType(schema = "api/response/Response.json")
-public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMResponseAttributes> promptTemplate(
-                            @Config InferenceConfiguration configuration,
-                            @Content String template, @Content String instructions, 
-                            @Content(primary = true) String data ) 
-                            throws Exception {
-   try {
-      JSONArray messagesArray = new JSONArray();
-      JSONObject systemMessage = new JSONObject();
-      systemMessage.put("role", "system");
-      systemMessage.put("content", template + " - " + instructions);
-      messagesArray.put(systemMessage);
+    /**
+     * Define a prompt template with instructions and data
+     * @param configuration the connector configuration
+     * @param template the template string
+     * @param instructions instructions for the LLM
+     * @param data the primary data content
+     * @return result containing the LLM response
+     * @throws ModuleException if an error occurs during the operation
+     */
+    @MediaType(value = APPLICATION_JSON, strict = false)
+    @Alias("Agent-define-prompt-template")
+    @OutputJsonType(schema = "api/response/Response.json")
+    public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMResponseAttributes> promptTemplate(
+            @Config InferenceConfiguration configuration,
+            @Content String template,
+            @Content String instructions,
+            @Content(primary = true) String data) throws ModuleException {
+        try {
+            JSONArray messagesArray = new JSONArray();
+            JSONObject systemMessage = new JSONObject();
+            systemMessage.put("role", "system");
+            systemMessage.put("content", template + " - " + instructions);
+            messagesArray.put(systemMessage);
 
-      JSONObject usersPrompt = new JSONObject();
-      usersPrompt.put("role", "user");
-      usersPrompt.put("content", data);
-      messagesArray.put(usersPrompt);
+            JSONObject usersPrompt = new JSONObject();
+            usersPrompt.put("role", "user");
+            usersPrompt.put("content", data);
+            messagesArray.put(usersPrompt);
 
+            URL chatCompUrl = getConnectionURLChatCompletion(configuration);
+            JSONObject payload = buildPayload(configuration, messagesArray, null);
+            String response = executeREST(chatCompUrl, configuration, payload.toString());
 
-      URL chatCompUrl = getConnectionURLChatCompletion(configuration);
-
-      JSONObject payload = getPayload(configuration, messagesArray, null);
-
-      String response = executeREST(chatCompUrl,configuration, payload.toString());
-
-
-      JSONObject root = new JSONObject(response);
-      String model = root.getString("model");      
-      String id = !"OLLAMA".equals(configuration.getInferenceType()) ? root.getString("id") : null;
-      JSONObject message;
-      String finishReason;
-
-      if (!"OLLAMA".equals(configuration.getInferenceType())) {
-        JSONArray choicesArray = root.getJSONArray("choices");
-        JSONObject firstChoice = choicesArray.getJSONObject(0);
-        // aw add/nim finishReason = firstChoice.getString("finish_reason");
-        finishReason = !"NVIDIA".equals(configuration.getInferenceType()) ? firstChoice.getString("finish_reason") : "";
-        message = firstChoice.getJSONObject("message");
-
-      } else {
-        message = root.getJSONObject("message");
-        finishReason = root.getString("done_reason");
-      }
-
-      String content = message.getString("content");
-
-      TokenUsage tokenUsage = TokenHelper.parseUsageFromResponse(response);
-      JSONObject jsonObject = new JSONObject();
-      jsonObject.put(InferenceConstants.RESPONSE, content);
-      Map<String, String> responseAttributes = new HashMap<>();;
-      responseAttributes.put(InferenceConstants.FINISH_REASON, finishReason); 
-      responseAttributes.put(InferenceConstants.MODEL, model); 
-      responseAttributes.put(InferenceConstants.ID_STRING, id); 
-
-      LOGGER.debug("Agent define prompt template result {}", response);
-
-      return createLLMResponse(jsonObject.toString(), tokenUsage, responseAttributes);
-     } catch (Exception e) {
-      throw new org.mule.runtime.extension.api.exception.ModuleException("Agent define prompt template result {}", InferenceErrorType.CHAT_COMPLETION, e);
-      //LOGGER.debug("Error in chat completions {}", e.getMessage());
-      //System.out.println(e.getMessage());
-
+            LOGGER.debug("Agent define prompt template result {}", response);
+            return processLLMResponse(response, configuration);
+        } catch (Exception e) {
+            LOGGER.error("Error in agent define prompt template: {}", e.getMessage(), e);
+            throw new ModuleException(String.format(ERROR_MSG_FORMAT, "Agent define prompt template"),
+                    InferenceErrorType.CHAT_COMPLETION, e);
+        }
     }
-  }
 
-  /**
- * Define a tools template
- * @throws Exception 
-*/
-@MediaType(value = APPLICATION_JSON, strict = false)
-@Alias("Tools-native-template")
-@OutputJsonType(schema = "api/response/Response.json")
-public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMResponseAttributes> toolsTemplate(
-                            @Config InferenceConfiguration configuration,
-                            @Content String template, @Content String instructions, 
-                            @Content(primary = true) String data, @Content InputStream tools) 
-                            throws Exception {
-   try {
-      JSONArray toolsArray = getInputString(tools);
+    /**
+     * Define a tools template with instructions, data and tools
+     * @param configuration the connector configuration
+     * @param template the template string
+     * @param instructions instructions for the LLM
+     * @param data the primary data content
+     * @param tools tools configuration as a JSON array
+     * @return result containing the LLM response
+     * @throws ModuleException if an error occurs during the operation
+     */
+    @MediaType(value = APPLICATION_JSON, strict = false)
+    @Alias("Tools-native-template")
+    @OutputJsonType(schema = "api/response/Response.json")
+    public org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMResponseAttributes> toolsTemplate(
+            @Config InferenceConfiguration configuration,
+            @Content String template,
+            @Content String instructions,
+            @Content(primary = true) String data,
+            @Content InputStream tools) throws ModuleException {
+        try {
+            JSONArray toolsArray = parseInputStreamToJsonArray(tools);
+            JSONArray messagesArray = new JSONArray();
 
-      JSONArray messagesArray = new JSONArray();
-      JSONObject systemMessage = new JSONObject();
-      systemMessage.put("role", "system");
-      systemMessage.put("content", template + " - " + instructions);
-      messagesArray.put(systemMessage);
+            JSONObject systemMessage = new JSONObject();
+            systemMessage.put("role", "system");
+            systemMessage.put("content", template + " - " + instructions);
+            messagesArray.put(systemMessage);
 
-      JSONObject usersPrompt = new JSONObject();
-      usersPrompt.put("role", "user");
-      usersPrompt.put("content", data);
-      messagesArray.put(usersPrompt);
+            JSONObject usersPrompt = new JSONObject();
+            usersPrompt.put("role", "user");
+            usersPrompt.put("content", data);
+            messagesArray.put(usersPrompt);
 
-      URL chatCompUrl = getConnectionURLChatCompletion(configuration);
-      JSONObject payload = getPayload(configuration, messagesArray, toolsArray);
-      String response = executeREST(chatCompUrl,configuration, payload.toString());
+            URL chatCompUrl = getConnectionURLChatCompletion(configuration);
+            JSONObject payload = buildPayload(configuration, messagesArray, toolsArray);
+            String response = executeREST(chatCompUrl, configuration, payload.toString());
 
+            LOGGER.debug("Tools use native template result {}", response);
+            return processToolsResponse(response, configuration);
+        } catch (Exception e) {
+            LOGGER.error("Error in tools use native template: {}", e.getMessage(), e);
+            throw new ModuleException(String.format(ERROR_MSG_FORMAT, "Tools use native template"),
+                    InferenceErrorType.CHAT_COMPLETION, e);
+        }
+    }
 
-      JSONObject root = new JSONObject(response);
-      String model = root.getString("model");      
-      String id = !"OLLAMA".equals(configuration.getInferenceType()) ? root.getString("id") : null;
-      JSONObject message;
-      String finishReason;
+    /**
+     * Process the response from the LLM API for standard chat operations
+     * @param response the response string from the API
+     * @param configuration the connector configuration
+     * @return result containing the LLM response
+     * @throws Exception if an error occurs during processing
+     */
+    private org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMResponseAttributes> processLLMResponse(
+            String response, InferenceConfiguration configuration) throws Exception {
 
-      if (!"OLLAMA".equals(configuration.getInferenceType())) {
-        JSONArray choicesArray = root.getJSONArray("choices");
-        JSONObject firstChoice = choicesArray.getJSONObject(0);
-        // aw add/nim finishReason = firstChoice.getString("finish_reason");
-        finishReason = !"NVIDIA".equals(configuration.getInferenceType()) ? firstChoice.getString("finish_reason") : "";
-        message = firstChoice.getJSONObject("message");
+        JSONObject root = new JSONObject(response);
+        String model = root.getString("model");
+        String id = isOllama(configuration) ? null : root.getString("id");
+        JSONObject message;
+        String finishReason;
 
-      } else {
-        message = root.getJSONObject("message");
-        finishReason = root.getString("done_reason");
-      }
+        if (!isOllama(configuration)) {
+            JSONArray choicesArray = root.getJSONArray("choices");
+            JSONObject firstChoice = choicesArray.getJSONObject(0);
+            finishReason = isNvidia(configuration) ? "" : firstChoice.getString("finish_reason");
+            message = firstChoice.getJSONObject("message");
+        } else {
+            message = root.getJSONObject("message");
+            finishReason = root.getString("done_reason");
+        }
 
-      String content = message.has("content") && !message.isNull("content") ? message.getString("content") : null;
-      JSONArray tool_calls = message.has("tool_calls") ? message.getJSONArray("tool_calls") : null;
+        String content = message.getString("content");
 
+        TokenUsage tokenUsage = TokenHelper.parseUsageFromResponse(response);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put(InferenceConstants.RESPONSE, content);
 
-      JSONArray toolCalls = new JSONArray();
-      if (tool_calls != null) {
-        for (int i = 0; i < tool_calls.length(); i++) {
-            JSONObject toolCall = tool_calls.getJSONObject(i);
-    
-            // Check if "function" and "arguments" are present in each tool call
+        Map<String, String> responseAttributes = new HashMap<>();
+        responseAttributes.put(InferenceConstants.FINISH_REASON, finishReason);
+        responseAttributes.put(InferenceConstants.MODEL, model);
+        responseAttributes.put(InferenceConstants.ID_STRING, id);
+
+        return createLLMResponse(jsonObject.toString(), tokenUsage, responseAttributes);
+    }
+
+    /**
+     * Process the response from the LLM API for tools operations
+     * @param response the response string from the API
+     * @param configuration the connector configuration
+     * @return result containing the LLM response
+     * @throws Exception if an error occurs during processing
+     */
+    private org.mule.runtime.extension.api.runtime.operation.Result<InputStream, LLMResponseAttributes> processToolsResponse(
+            String response, InferenceConfiguration configuration) throws Exception {
+
+        JSONObject root = new JSONObject(response);
+        String model = root.getString("model");
+        String id = isOllama(configuration) ? null : root.getString("id");
+        JSONObject message;
+        String finishReason;
+
+        if (!isOllama(configuration)) {
+            JSONArray choicesArray = root.getJSONArray("choices");
+            JSONObject firstChoice = choicesArray.getJSONObject(0);
+            finishReason = isNvidia(configuration) ? "" : firstChoice.getString("finish_reason");
+            message = firstChoice.getJSONObject("message");
+        } else {
+            message = root.getJSONObject("message");
+            finishReason = root.getString("done_reason");
+        }
+
+        String content = message.has("content") && !message.isNull("content") ? message.getString("content") : null;
+        JSONArray toolCalls = message.has("tool_calls") ? processToolCalls(message.getJSONArray("tool_calls")) : new JSONArray();
+
+        TokenUsage tokenUsage = TokenHelper.parseUsageFromResponse(response);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put(InferenceConstants.RESPONSE, content);
+        jsonObject.put(InferenceConstants.TOOLS, toolCalls);
+
+        Map<String, String> responseAttributes = new HashMap<>();
+        responseAttributes.put(InferenceConstants.FINISH_REASON, finishReason);
+        responseAttributes.put(InferenceConstants.MODEL, model);
+        responseAttributes.put(InferenceConstants.ID_STRING, id);
+
+        return createLLMResponse(jsonObject.toString(), tokenUsage, responseAttributes);
+    }
+
+    /**
+     * Process tool calls from the LLM response
+     * @param toolCalls the raw tool calls JSON array
+     * @return processed tool calls JSON array
+     */
+    private JSONArray processToolCalls(JSONArray toolCalls) {
+        JSONArray processedToolCalls = new JSONArray();
+
+        for (int i = 0; i < toolCalls.length(); i++) {
+            JSONObject toolCall = toolCalls.getJSONObject(i);
+
             if (toolCall.has("function")) {
                 JSONObject functionObject = toolCall.getJSONObject("function");
-    
+
                 if (functionObject.has("arguments")) {
                     // Convert "arguments" from a string to a JSON object
                     JSONObject arguments = new JSONObject(functionObject.getString("arguments"));
                     functionObject.put("arguments", arguments);
                 }
             }
-      
-              toolCalls.put(toolCall);
-          }
-      }
-      TokenUsage tokenUsage = TokenHelper.parseUsageFromResponse(response);
-      JSONObject jsonObject = new JSONObject();
-      jsonObject.put(InferenceConstants.RESPONSE, content);
-      jsonObject.put(InferenceConstants.TOOLS, toolCalls);
-      Map<String, String> responseAttributes = new HashMap<>();;
-      responseAttributes.put(InferenceConstants.FINISH_REASON, finishReason); 
-      responseAttributes.put(InferenceConstants.MODEL, model); 
-      responseAttributes.put(InferenceConstants.ID_STRING, id); 
 
-      LOGGER.debug("Tools use native template result {}", response);
+            processedToolCalls.put(toolCall);
+        }
 
-      return createLLMResponse(jsonObject.toString(), tokenUsage, responseAttributes);
-     } catch (Exception e) {
-      throw new org.mule.runtime.extension.api.exception.ModuleException("Tools use native template result {}", InferenceErrorType.CHAT_COMPLETION, e);
-      //LOGGER.debug("Error in chat completions {}", e.getMessage());
-      //System.out.println(e.getMessage());
-
+        return processedToolCalls;
     }
-  }
 
+    /**
+     * Build the HTTP connection for the API request
+     * @param url the URL to connect to
+     * @param configuration the connector configuration
+     * @return the configured HTTP connection
+     * @throws IOException if an error occurs during connection setup
+     */
+    private static HttpURLConnection getConnectionObject(URL url, InferenceConfiguration configuration) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setDoOutput(true);
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("User-Agent", "Mozilla/5.0");
+        conn.setRequestProperty("Accept", "application/json");
 
-  private static HttpURLConnection getConnectionObject(URL url, InferenceConfiguration configuration) throws IOException {
-    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    conn.setDoOutput(true);
-    conn.setRequestMethod("POST");
-    //conn.setRequestProperty("Content-Type", "application/json;charset=utf-8");    
-    conn.setRequestProperty("Content-Type", "application/json");
-    conn.setRequestProperty("User-Agent", "Mozilla/5.0");  
-    conn.setRequestProperty("Accept", "application/json");  
-    switch (configuration.getInferenceType()) {
-        case "PORTKEY":
+        if ("PORTKEY".equals(configuration.getInferenceType())) {
             conn.setRequestProperty("x-portkey-api-key", configuration.getApiKey());
             conn.setRequestProperty("x-portkey-virtual-key", configuration.getVirtualKey());
-        default:
-            conn.setRequestProperty("Authorization", "Bearer " + configuration.getApiKey());;
-    
-    }
-
-    return conn;
-  }
-
-  private static URL getConnectionURLChatCompletion(InferenceConfiguration configuration) throws MalformedURLException {
-    switch (configuration.getInferenceType()) {
-        case "PORTKEY":
-            return new URL(InferenceConstants.PORTKEY_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "GROQ":
-            return new URL(InferenceConstants.GROQ_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "HUGGING_FACE": 
-            return new URL(InferenceConstants.HUGGINGFACE_URL + "/models/" + configuration.getModelName() + "/v1" + InferenceConstants.CHAT_COMPLETIONS);
-        case "OPENROUTER": 
-            return new URL(InferenceConstants.OPENROUTER_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "GITHUB": 
-            return new URL(InferenceConstants.GITHUB_MODELS_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "OLLAMA": 
-            return new URL(configuration.getOllamaUrl() + InferenceConstants.CHAT_COMPLETIONS_OLLAMA);
-        case "CEREBRAS": 
-            return new URL(InferenceConstants.CEREBRAS_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "NVIDIA": 
-            return new URL(InferenceConstants.NVIDIA_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "FIREWORKS": 
-            return new URL(InferenceConstants.FIREWORKS_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "TOGETHER": 
-            return new URL(InferenceConstants.TOGETHER_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "DEEPINFRA": 
-            return new URL(InferenceConstants.DEEPINFRA_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "PERPLEXITY":
-            return new URL(InferenceConstants.PERPLEXITY_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "XAI":
-            return new URL(InferenceConstants.X_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "OPENAI":
-            return new URL(InferenceConstants.OPEN_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
-        case "MISTRAL":
-            return new URL(InferenceConstants.MISTRAL_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
-        default:
-            return new URL ("");
+        } else {
+            conn.setRequestProperty("Authorization", "Bearer " + configuration.getApiKey());
         }
-  }
 
-  private static JSONObject getPayload(InferenceConfiguration configuration, JSONArray messagesArray, JSONArray toolsArray){
-    JSONObject payload = new JSONObject();
-    payload.put(InferenceConstants.MODEL, configuration.getModelName());
-    payload.put(InferenceConstants.MESSAGES, messagesArray);
-
-    if ("GROQ".equalsIgnoreCase(configuration.getInferenceType()) || "OPENAI".equalsIgnoreCase(configuration.getInferenceType())) {
-      payload.put(InferenceConstants.MAX_COMPLETION_TOKENS, configuration.getMaxTokens());
-    } else {
-      payload.put(InferenceConstants.MAX_TOKENS, configuration.getMaxTokens());
+        return conn;
     }
 
-    String[] noTemperatureModels = {"o3-mini", "o1", "o1-mini"};
-    if (!Arrays.asList(noTemperatureModels).contains(configuration.getModelName())) {
-      payload.put(InferenceConstants.TEMPERATURE, configuration.getTemperature());
-      payload.put(InferenceConstants.TOP_P, configuration.getTopP());
+    /**
+     * Get the appropriate URL for chat completion based on the configuration
+     * @param configuration the connector configuration
+     * @return the URL for the chat completion endpoint
+     * @throws MalformedURLException if the URL is invalid
+     */
+    private static URL getConnectionURLChatCompletion(InferenceConfiguration configuration) throws MalformedURLException {
+        String baseUrl;
+        String path;
+
+        switch (configuration.getInferenceType()) {
+            case "PORTKEY":
+                return new URL(InferenceConstants.PORTKEY_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "GROQ":
+                return new URL(InferenceConstants.GROQ_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "HUGGING_FACE":
+                return new URL(InferenceConstants.HUGGINGFACE_URL + "/models/" + configuration.getModelName() + "/v1" + InferenceConstants.CHAT_COMPLETIONS);
+            case "OPENROUTER":
+                return new URL(InferenceConstants.OPENROUTER_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "GITHUB":
+                return new URL(InferenceConstants.GITHUB_MODELS_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "OLLAMA":
+                return new URL(configuration.getOllamaUrl() + InferenceConstants.CHAT_COMPLETIONS_OLLAMA);
+            case "CEREBRAS":
+                return new URL(InferenceConstants.CEREBRAS_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "NVIDIA":
+                return new URL(InferenceConstants.NVIDIA_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "FIREWORKS":
+                return new URL(InferenceConstants.FIREWORKS_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "TOGETHER":
+                return new URL(InferenceConstants.TOGETHER_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "DEEPINFRA":
+                return new URL(InferenceConstants.DEEPINFRA_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "PERPLEXITY":
+                return new URL(InferenceConstants.PERPLEXITY_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "XAI":
+                return new URL(InferenceConstants.X_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "OPENAI":
+                return new URL(InferenceConstants.OPEN_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
+            case "MISTRAL":
+                return new URL(InferenceConstants.MISTRAL_AI_URL + InferenceConstants.CHAT_COMPLETIONS);
+            default:
+                throw new MalformedURLException("Unsupported inference type: " + configuration.getInferenceType());
+        }
     }
 
-    payload.put(InferenceConstants.TOOLS, toolsArray != null ? toolsArray : null);
-    payload.put("stream", "OLLAMA".equals(configuration.getInferenceType()) ? false : null);
+    /**
+     * Build the payload for the API request
+     * @param configuration the connector configuration
+     * @param messagesArray the messages array
+     * @param toolsArray the tools array (can be null)
+     * @return the payload as a JSON object
+     */
+    private static JSONObject buildPayload(InferenceConfiguration configuration, JSONArray messagesArray, JSONArray toolsArray) {
+        JSONObject payload = new JSONObject();
+        payload.put(InferenceConstants.MODEL, configuration.getModelName());
+        payload.put(InferenceConstants.MESSAGES, messagesArray);
 
-    return payload;
+        // Different max token parameter names for different providers
+        if ("GROQ".equalsIgnoreCase(configuration.getInferenceType()) || "OPENAI".equalsIgnoreCase(configuration.getInferenceType())) {
+            payload.put(InferenceConstants.MAX_COMPLETION_TOKENS, configuration.getMaxTokens());
+        } else {
+            payload.put(InferenceConstants.MAX_TOKENS, configuration.getMaxTokens());
+        }
 
-  }
+        // Some models don't support temperature/top_p parameters
+        if (!Arrays.asList(NO_TEMPERATURE_MODELS).contains(configuration.getModelName())) {
+            payload.put(InferenceConstants.TEMPERATURE, configuration.getTemperature());
+            payload.put(InferenceConstants.TOP_P, configuration.getTopP());
+        }
 
-  private static JSONArray getInputString(InputStream inputString) throws IOException {
-    InputStreamReader reader = new InputStreamReader(inputString);
-    StringBuilder inputStringBuilder = new StringBuilder();
-    int c;
-    while ((c = reader.read()) != -1) {
-        inputStringBuilder.append((char) c);
+        // Add tools array if provided
+        if (toolsArray != null) {
+            payload.put(InferenceConstants.TOOLS, toolsArray);
+        }
+
+        // Special handling for Ollama's stream parameter
+        if ("OLLAMA".equals(configuration.getInferenceType())) {
+            payload.put("stream", false);
+        }
+
+        return payload;
     }
-    return new JSONArray(inputStringBuilder.toString());
 
-  }
+    /**
+     * Parse an input stream to a JSON array
+     * @param inputStream the input stream to parse
+     * @return the parsed JSON array
+     * @throws IOException if an error occurs during parsing
+     */
+    private static JSONArray parseInputStreamToJsonArray(InputStream inputStream) throws IOException {
+        try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+             BufferedReader bufferedReader = new BufferedReader(reader)) {
 
-  private static String executeREST(URL ressourceUrl, InferenceConfiguration configuration, String payload) {
+            StringBuilder stringBuilder = new StringBuilder();
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                stringBuilder.append(line);
+            }
 
-    try {
-        URL url = ressourceUrl;
+            return new JSONArray(stringBuilder.toString());
+        }
+    }
 
-        HttpURLConnection conn = getConnectionObject(url, configuration);
-
+    /**
+     * Execute a REST API call
+     * @param resourceUrl the URL to call
+     * @param configuration the connector configuration
+     * @param payload the payload to send
+     * @return the response string
+     * @throws IOException if an error occurs during the API call
+     */
+    private static String executeREST(URL resourceUrl, InferenceConfiguration configuration, String payload) throws IOException {
+        HttpURLConnection conn = getConnectionObject(resourceUrl, configuration);
 
         // Send the payload
         try (OutputStream os = conn.getOutputStream()) {
             byte[] input = payload.getBytes(StandardCharsets.UTF_8);
             os.write(input, 0, input.length);
-            os.flush();  // Ensure data is sent
+            os.flush();
         }
 
         int responseCode = conn.getResponseCode();
 
         if (responseCode == HttpURLConnection.HTTP_OK) {
-
-          try (BufferedReader br = new BufferedReader(
+            // Read successful response
+            try (BufferedReader br = new BufferedReader(
                     new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
                 StringBuilder response = new StringBuilder();
                 String responseLine;
                 while ((responseLine = br.readLine()) != null) {
-                    response.append(responseLine.trim());
+                    response.append(responseLine);
                 }
                 return response.toString();
             }
         } else {
-
+            // Read error response
+            StringBuilder errorResponse = new StringBuilder();
             try (BufferedReader errorReader = new BufferedReader(
                     new InputStreamReader(conn.getErrorStream(), StandardCharsets.UTF_8))) {
-                StringBuilder errorResponse = new StringBuilder();
                 String errorLine;
                 while ((errorLine = errorReader.readLine()) != null) {
-                    errorResponse.append(errorLine.trim());
+                    errorResponse.append(errorLine);
                 }
-            } catch (IOException ex) {
-                LOGGER.debug("Error reading error stream {}", ex.getMessage());
-
             }
-            return "Error: " + responseCode;
+
+            LOGGER.error("API request failed with status code: {} and message: {}", responseCode, errorResponse);
+            throw new IOException("API request failed with status code: " + responseCode +
+                    " and message: " + errorResponse);
         }
-    } catch (Exception e) {
-        e.printStackTrace();
-        return "Exception occurred: " + e.getMessage();
     }
-}
 
+    /**
+     * Check if the inference type is OLLAMA
+     * @param configuration the connector configuration
+     * @return true if the inference type is OLLAMA, false otherwise
+     */
+    private boolean isOllama(InferenceConfiguration configuration) {
+        return "OLLAMA".equals(configuration.getInferenceType());
+    }
 
+    /**
+     * Check if the inference type is NVIDIA
+     * @param configuration the connector configuration
+     * @return true if the inference type is NVIDIA, false otherwise
+     */
+    private boolean isNvidia(InferenceConfiguration configuration) {
+        return "NVIDIA".equals(configuration.getInferenceType());
+    }
 }


### PR DESCRIPTION
### Release 0.3.0

Additional model provider added
- OpenAI
- Mistral
- Perplexity

## Supported Inference Providers
The MuleSoft Inference Connector supports the following Inference Offerings:

- [GitHub Models](https://docs.github.com/en/github-models)
- [Hugging Face](https://huggingface.co/)
- [Ollama](https://ollama.com/)
- [Groq AI](https://console.groq.com/)
- [Portkey](https://portkey.ai/)
- [OpenAI](https://openai.com/)
- [XAI](https://x.ai/)
- [Perplexity](https://www.perplexity.ai/)
- [Mistral](https://www.mistral.ai/)
- [OpenRouter](https://openrouter.ai/)
- [Cerebras](https://cerebras.ai/inference)
- [NVIDIA](https://www.nvidia.com/en-sg/ai)
- [Together.ai](https://www.together.ai/)
- [Fireworks](https://fireworks.ai/)
- [DeepInfra](https://deepinfra.com/)

