### PR TITLE
added readImage support for Vertex AI Express Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ generated-test-sources/
 *.sh
 
 
+/bin/

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The MuleSoft Inference Connector supports the following Inference Offerings:
 - [Portkey](https://portkey.ai/)
 - [Hugging Face](https://huggingface.co/)
 - [GitHub Models](https://docs.github.com/en/github-models)
+- [Google Vertex AI](https://cloud.google.com/vertex-ai?hl=en)
 
 ### Requirements
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-inference-connector</artifactId>
-    <version>0.4.74-SNAPSHOT</version>
+    <version>0.4.75-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Inference Connector - Mule 4</name>
 	<description>MuleSoft Inference Connector for integrating LLM Inference APIs into MuleSoft.</description>

--- a/src/main/java/com/mulesoft/connectors/internal/models/vision/ModelType.java
+++ b/src/main/java/com/mulesoft/connectors/internal/models/vision/ModelType.java
@@ -31,6 +31,7 @@ public enum ModelType {
       HUGGING_FACE("HUGGING_FACE", getHuggingFaceModelNameStream()),
       GITHUB("GITHUB", getGithubModelNameStream()),
       OLLAMA("OLLAMA", getOllamaModelNameStream()),
+      VERTEX_AI_EXPRESS("VERTEX_AI_EXPRESS", getVertexAIExpressModelNameStream())
 
   ;
 
@@ -130,6 +131,11 @@ public enum ModelType {
   private static Stream<String> getAzureOpenAIModelNameStream() {
     return Arrays.stream(AzureOpenAIModelName.values()).map(String::valueOf);
   }
+  
+  private static Stream<String> getVertexAIExpressModelNameStream() {
+	    return Arrays.stream(VertexAIExpressModelName.values()).map(String::valueOf);
+  }
+
 
   public static ModelType fromValue(String value) {
     return Arrays.stream(ModelType.values())
@@ -475,4 +481,25 @@ public enum ModelType {
       return this.value;
     }
   }
+  
+  enum VertexAIExpressModelName {
+	    GEMINI_20_FLASH_001("gemini-2.0-flash-001"), 
+	    GEMINI_20_FLASH_LITE_001("gemini-2.0-flash-lite-001"),
+	    GEMINI_20_PRO_EXP_02_05("gemini-2.0-pro-exp-02-05"),  //Experimental
+	    GEMINI_15_FLASH_002("gemini-1.5-flash-002"),  //expires 9/24/25 
+	    GEMINI_15_PRO_002("gemini-1.5-pro-002"),      //expires 9/24/25
+	    GEMINI_10_PRO_002("gemini-1.0-pro-002");      //expires 4/9/25
+
+	    private final String value;
+
+	    VertexAIExpressModelName(String value) {
+	      this.value = value;
+	    }
+
+	    @Override
+	    public String toString() {
+	      return this.value;
+	    }
+  }
+
 }


### PR DESCRIPTION
added support for readImage (parsing image) for Vertex AI Express Mode.
it supports both base64 encoded or fileURI
u can use this for testing - gs://cloud-samples-data/generative-ai/image/mount_fuji.jpg