### PR TITLE
Fixed MCP tool response for non JSON output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-inference-connector</artifactId>
-    <version>0.5.6-SNAPSHOT</version>
+    <version>0.5.7</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Inference Connector - Mule 4</name>
 	<description>MuleSoft Inference Connector for integrating LLM Inference APIs into MuleSoft.</description>

--- a/src/main/java/com/mulesoft/connectors/internal/utils/ConnectionUtils.java
+++ b/src/main/java/com/mulesoft/connectors/internal/utils/ConnectionUtils.java
@@ -285,6 +285,8 @@ public class ConnectionUtils {
         if (resourceUrl == null) {
             throw new IllegalArgumentException("Resource URL cannot be null");
         }
+        LOGGER.debug("Sending request to URL: {}", resourceUrl);
+        LOGGER.trace("Payload: {} ", payload);
         HttpRequest initialRequest = buildHttpRequest(resourceUrl, connection);
         MultiMap<String, String> headersMultiMap = initialRequest.getHeaders();
         Map<String, String> headersMap = new HashMap<>();

--- a/src/main/java/com/mulesoft/connectors/internal/utils/PayloadUtils.java
+++ b/src/main/java/com/mulesoft/connectors/internal/utils/PayloadUtils.java
@@ -742,6 +742,19 @@ public class PayloadUtils {
         return requestPayload;
     }
 
+    public static boolean isValidJson(String json) {
+        try {
+            new JSONObject(json);
+            return true;
+        } catch (Exception ex1) {
+            try {
+                new JSONArray(json);
+                return true;
+            } catch (Exception ex2) {
+                return false;
+            }
+        }
+    }
 
 
 }

--- a/src/main/java/com/mulesoft/connectors/internal/utils/ProviderUtils.java
+++ b/src/main/java/com/mulesoft/connectors/internal/utils/ProviderUtils.java
@@ -429,7 +429,7 @@ public class ProviderUtils {
 
     public static JSONArray executeTools(String apiResponseJson) throws Exception {
 
-
+        LOGGER.debug("executeTools - Response from the tools server: {}", apiResponseJson);
         JSONArray resultsArray = new JSONArray();
 
 
@@ -461,13 +461,23 @@ public class ProviderUtils {
             JSONObject contentObj = new JSONObject();
             for (McpSchema.Content content : result.content()) {
                 if (content instanceof McpSchema.TextContent textContent) {
-                    contentObj.put("result", new JSONObject(textContent.text()));
+                    LOGGER.info("Debugging the exception. TextContent is {} ", textContent.text());
+                    if (PayloadUtils.isValidJson(textContent.text())) {
+                        contentObj.put("result", new JSONObject(textContent.text()));
+                    } else {
+                        contentObj.put("result", textContent.text());
+                    }
                 }
             }
 
             JSONObject resultObject = new JSONObject();
             resultObject.put("tool", functionName);
-            resultObject.put("result", contentObj.getJSONObject("result"));
+            try {
+                resultObject.put("result", contentObj.getJSONObject("result"));
+            } catch(Exception e) {
+                resultObject.put("result", contentObj.getString("result"));
+            }
+            
             resultObject.put("serverUrl", serverUrl);
             resultObject.put("serverName", serverName);
             resultObject.put("timestamp", Instant.now());


### PR DESCRIPTION
This PR fixes an issue that appears when an MCP tool responds with a plain text since the current code expects the tool to respond with a JSON string which is not always the case.