### PR TITLE
Feature/w-18848604  add tests for multiple inference types and image, moderation and vision operation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
 		<runtimeProduct>MULE_EE</runtimeProduct>
 		<skip.unit.tests>true</skip.unit.tests>
+		<mtf.tools.version>1.2.0</mtf.tools.version>
 
 		<formatterConfigPath>formatter.xml</formatterConfigPath>
 		<formatterGoal>validate</formatterGoal>
@@ -129,6 +130,20 @@
 						<phase>integration-test</phase>
 					</execution>
 				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>com.mulesoft.munit</groupId>
+						<artifactId>munit-tools</artifactId>
+						<version>${munit.version}</version>
+						<classifier>mule-plugin</classifier>
+					</dependency>
+					<dependency>
+						<groupId>com.mulesoft.munit</groupId>
+						<artifactId>mtf-tools</artifactId>
+						<version>${mtf.tools.version}</version>
+						<classifier>mule-plugin</classifier>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -296,10 +296,9 @@
 			<version>2.17.0</version>
 		</dependency>
 		<dependency>
-			<groupId>org.jetbrains</groupId>
-			<artifactId>annotations</artifactId>
-			<version>26.0.1</version>
-			<scope>compile</scope>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.17.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/mistralai/MistralAIModerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/mistralai/MistralAIModerationConnectionProvider.java
@@ -12,7 +12,6 @@ import org.mule.runtime.extension.api.annotation.values.OfValues;
 import com.mulesoft.connectors.inference.internal.connection.parameters.BaseConnectionParameters;
 import com.mulesoft.connectors.inference.internal.connection.provider.ModerationConnectionProvider;
 import com.mulesoft.connectors.inference.internal.connection.types.ModerationConnection;
-import com.mulesoft.connectors.inference.internal.constants.InferenceConstants;
 import com.mulesoft.connectors.inference.internal.llmmodels.mistral.providers.MistralAIModerationModelNameProvider;
 
 import org.slf4j.Logger;
@@ -25,6 +24,7 @@ public class MistralAIModerationConnectionProvider extends ModerationConnectionP
   private static final Logger logger = LoggerFactory.getLogger(MistralAIModerationConnectionProvider.class);
 
   public static final String MISTRAL_AI_URL = "https://api.mistral.ai/v1";
+  public static final String MODERATIONS_PATH = "/moderations";
 
   @Parameter
   @Expression(ExpressionSupport.SUPPORTED)
@@ -44,6 +44,6 @@ public class MistralAIModerationConnectionProvider extends ModerationConnectionP
   }
 
   private String getModerationAPIURL() {
-    return MISTRAL_AI_URL + InferenceConstants.MODERATIONS_PATH;
+    return MISTRAL_AI_URL + MODERATIONS_PATH;
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openai/OpenAIModerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openai/OpenAIModerationConnectionProvider.java
@@ -12,7 +12,6 @@ import org.mule.runtime.extension.api.annotation.values.OfValues;
 import com.mulesoft.connectors.inference.internal.connection.parameters.BaseConnectionParameters;
 import com.mulesoft.connectors.inference.internal.connection.provider.ModerationConnectionProvider;
 import com.mulesoft.connectors.inference.internal.connection.types.ModerationConnection;
-import com.mulesoft.connectors.inference.internal.constants.InferenceConstants;
 import com.mulesoft.connectors.inference.internal.llmmodels.openai.providers.OpenAIModerationModelNameProvider;
 
 import org.slf4j.Logger;
@@ -25,6 +24,7 @@ public class OpenAIModerationConnectionProvider extends ModerationConnectionProv
   private static final Logger logger = LoggerFactory.getLogger(OpenAIModerationConnectionProvider.class);
 
   public static final String OPEN_AI_URL = "https://api.openai.com/v1";
+  public static final String MODERATIONS_PATH = "/moderations";
 
   @Parameter
   @Expression(ExpressionSupport.SUPPORTED)
@@ -44,6 +44,6 @@ public class OpenAIModerationConnectionProvider extends ModerationConnectionProv
   }
 
   private String getModerationAPIURL() {
-    return OPEN_AI_URL + InferenceConstants.MODERATIONS_PATH;
+    return OPEN_AI_URL + MODERATIONS_PATH;
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/portkey/PortkeyVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/portkey/PortkeyVisionConnectionProvider.java
@@ -4,6 +4,7 @@ import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.meta.ExpressionSupport;
 import org.mule.runtime.extension.api.annotation.Alias;
 import org.mule.runtime.extension.api.annotation.Expression;
+import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
@@ -31,6 +32,13 @@ public class PortkeyVisionConnectionProvider extends VisionModelConnectionProvid
   @OfValues(PortkeyVisionModelNameProvider.class)
   private String portkeyModelName;
 
+  @Parameter
+  @Optional
+  @Expression(ExpressionSupport.SUPPORTED)
+  @Placement(order = 2)
+  @DisplayName("[Portkey] Virtual Key")
+  private String virtualKey;
+
   @ParameterGroup(name = Placement.CONNECTION_TAB)
   private TextGenerationConnectionParameters textGenerationConnectionParameters;
 
@@ -48,6 +56,7 @@ public class PortkeyVisionConnectionProvider extends VisionModelConnectionProvid
                                                                                              textGenerationConnectionParameters
                                                                                                  .getTopP(),
                                                                                              textGenerationConnectionParameters
-                                                                                                 .getTimeout()));
+                                                                                                 .getTimeout()),
+                                       virtualKey);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAIImageConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAIImageConnectionProvider.java
@@ -30,7 +30,7 @@ public class XAIImageConnectionProvider extends ImageGenerationConnectionProvide
   @Expression(ExpressionSupport.SUPPORTED)
   @OfValues(XAIImageModelNameProvider.class)
   @Placement(order = 1)
-  private String xAIModelName;
+  private String xAiModelName;
 
   @ParameterGroup(name = Placement.CONNECTION_TAB)
   private BaseConnectionParameters baseConnectionParameters;
@@ -39,7 +39,7 @@ public class XAIImageConnectionProvider extends ImageGenerationConnectionProvide
   public XAIImageGenerationConnection connect() {
     logger.debug("XAIImageConnection connect ...");
 
-    return new XAIImageGenerationConnection(getHttpClient(), getObjectMapper(), xAIModelName,
+    return new XAIImageGenerationConnection(getHttpClient(), getObjectMapper(), xAiModelName,
                                             baseConnectionParameters.getApiKey(),
                                             baseConnectionParameters.getTimeout(), getImageGenerationAPIURL());
   }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAITextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAITextGenerationConnectionProvider.java
@@ -29,7 +29,7 @@ public class XAITextGenerationConnectionProvider extends TextGenerationConnectio
   @Placement(order = 1)
   @Expression(ExpressionSupport.SUPPORTED)
   @OfValues(XAITextGenerationModelNameProvider.class)
-  private String xaiModelName;
+  private String xAiModelName;
 
   @ParameterGroup(name = Placement.CONNECTION_TAB)
   private TextGenerationConnectionParameters textGenerationConnectionParameters;
@@ -38,7 +38,7 @@ public class XAITextGenerationConnectionProvider extends TextGenerationConnectio
   public XAITextGenerationConnection connect() throws ConnectionException {
     logger.debug("XAITextGenerationConnection connect ...");
     return new XAITextGenerationConnection(getHttpClient(), getObjectMapper(),
-                                           new ParametersDTO(xaiModelName,
+                                           new ParametersDTO(xAiModelName,
                                                              textGenerationConnectionParameters.getApiKey(),
                                                              textGenerationConnectionParameters.getMaxTokens(),
                                                              textGenerationConnectionParameters.getTemperature(),

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAIVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAIVisionConnectionProvider.java
@@ -29,7 +29,7 @@ public class XAIVisionConnectionProvider extends VisionModelConnectionProvider {
   @Placement(order = 1)
   @Expression(ExpressionSupport.SUPPORTED)
   @OfValues(XAIVisionModelNameProvider.class)
-  private String xaiModelName;
+  private String xAiModelName;
 
   @ParameterGroup(name = Placement.CONNECTION_TAB)
   private TextGenerationConnectionParameters textGenerationConnectionParameters;
@@ -38,7 +38,7 @@ public class XAIVisionConnectionProvider extends VisionModelConnectionProvider {
   public XAIVisionConnection connect() throws ConnectionException {
     logger.debug("XAIVisionConnection connect ...");
     return new XAIVisionConnection(getHttpClient(), getObjectMapper(), new ParametersDTO(
-                                                                                         xaiModelName,
+                                                                                         xAiModelName,
                                                                                          textGenerationConnectionParameters
                                                                                              .getApiKey(),
                                                                                          textGenerationConnectionParameters

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/portkey/PortkeyVisionConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/portkey/PortkeyVisionConnection.java
@@ -5,16 +5,25 @@ import org.mule.runtime.http.api.client.HttpClient;
 import com.mulesoft.connectors.inference.internal.connection.types.VisionModelConnection;
 import com.mulesoft.connectors.inference.internal.dto.ParametersDTO;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class PortkeyVisionConnection extends VisionModelConnection {
 
   private static final String URI_CHAT_COMPLETIONS = "/chat/completions";
   public static final String PORTKEY_URL = "https://api.portkey.ai/v1";
+  private final String virtualKey;
 
   public PortkeyVisionConnection(HttpClient httpClient, ObjectMapper objectMapper,
-                                 ParametersDTO parametersDTO) {
+                                 ParametersDTO parametersDTO, String virtualKey) {
     super(httpClient, objectMapper, parametersDTO, fetchApiURL());
+    this.virtualKey = virtualKey;
+  }
+
+  @Override
+  public Map<String, String> getAdditionalHeaders() {
+    return Map.of("x-portkey-api-key", this.getApiKey(), "x-portkey-virtual-key", this.virtualKey);
   }
 
   private static String fetchApiURL() {

--- a/src/main/java/com/mulesoft/connectors/inference/internal/constants/InferenceConstants.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/constants/InferenceConstants.java
@@ -11,61 +11,9 @@ public class InferenceConstants {
 
   public static final String HEADER_CONTENT_TYPE = "Content-Type";
 
-
-  public static final String PORTKEY_URL = "https://api.portkey.ai/v1";
-  public static final String HUGGINGFACE_URL = "https://router.huggingface.co/hf-inference";
-  public static final String GROQ_URL = "https://api.groq.com/openai/v1";
-  public static final String OPENROUTER_URL = "https://openrouter.ai/api/v1";
-  public static final String GITHUB_MODELS_URL = "https://models.inference.ai.azure.com";
-  public static final String CEREBRAS_URL = "https://api.cerebras.ai/v1";
-  public static final String NVIDIA_URL = "https://integrate.api.nvidia.com/v1";
-  public static final String FIREWORKS_URL = "https://api.fireworks.ai/inference/v1";
-  public static final String TOGETHER_URL = "https://api.together.xyz/v1";
-  public static final String DEEPINFRA_URL = "https://api.deepinfra.com/v1/openai";
-  public static final String PERPLEXITY_URL = "https://api.perplexity.ai";
-  public static final String X_AI_URL = "https://api.x.ai/v1";
-  public static final String OPEN_AI_URL = "https://api.openai.com/v1";
-  public static final String MISTRAL_AI_URL = "https://api.mistral.ai/v1";
-  public static final String ANTHROPIC_URL = "https://api.anthropic.com/v1";
-  public static final String AI21LABS_URL = "https://api.ai21.com/studio/v1";
-  public static final String COHERE_URL = "https://api.cohere.com/v2";
-  public static final String AZURE_OPENAI_URL = "https://{resource-name}.openai.azure.com/openai/deployments/{deployment-id}";
-  public static final String VERTEX_AI_EXPRESS_URL = "https://aiplatform.googleapis.com/v1/publishers/google/models/{MODEL_ID}:";
-  public static final String AZURE_AI_FOUNDRY_URL = "https://{resource-name}.services.ai.azure.com/models";
   public static final String GPT4ALL_URL = "http://localhost:4891/v1";
   public static final String LMSTUDIO_URL = "http://localhost:1234/v1";
   public static final String DOCKER_MODEL_URL = "http://localhost:12434";
-  public static final String DEEPSEEK_URL = "https://api.deepseek.com";
-  public static final String ZHIPU_AI_URL = "https://open.bigmodel.cn/api/paas/v4";
-  public static final String VERTEX_AI_GEMINI_URL =
-      "https://{LOCATION_ID}-aiplatform.googleapis.com/v1/projects/{PROJECT_ID}/locations/{LOCATION_ID}/publishers/google/models/{MODEL_ID}:";
-  public static final String VERTEX_AI_ANTHROPIC_URL =
-      "https://{LOCATION_ID}-aiplatform.googleapis.com/v1/projects/{PROJECT_ID}/locations/{LOCATION_ID}/publishers/anthropic/models/{MODEL_ID}:";
-  public static final String VERTEX_AI_META_URL =
-      "https://{LOCATION_ID}-aiplatform.googleapis.com/v1beta1/projects/{PROJECT_ID}/locations/{LOCATION_ID}/endpoints/openapi/chat/completions";
-  public static final String OPENAI_COMPATIBLE_ENDPOINT = "https://server.endpoint.com";
-  public static final String IBM_WATSON_URL = "https://us-south.ml.cloud.ibm.com/ml/v1/text";
-  public static final String IBM_WATSON_TOKEN_URL = "https://iam.cloud.ibm.com/identity/token";
-  public static final String STABILITY_AI_URL = "https://api.stability.ai";
-  public static final String LLM_API_URL = "https://api.llmapi.com";
-
-  // Resources
-  public static final String CHAT_COMPLETIONS = "/chat/completions";
-  public static final String CHAT_COMPLETIONS_AZURE = "/chat/completions?api-version=2024-10-21";
-  public static final String CHAT_COMPLETIONS_AZURE_AI_FOUNDRY = "/chat/completions?api-version={api-version}";
-  public static final String CHAT_COMPLETIONS_IBM_WATSON = "/chat?version={api-version}";
-  public static final String CHAT_COMPLETIONS_OLLAMA = "/chat";
-  public static final String GENERATION_OLLAMA = "/generate";
-  public static final String GENERATE_CONTENT_VERTEX_AI_GEMINI = "generateContent";
-  public static final String GENERATE_CONTENT_VERTEX_AI_ANTHROPIC = "rawPredict";
-  public static final String OPENAI_GENERATE_IMAGES = "/images/generations";
-  public static final String VERTEX_AI_ANTHROPIC_VERSION = "anthropic_version";
-  public static final String VERTEX_AI_ANTHROPIC_VERSION_VALUE = "vertex-2023-10-16";
-  public static final String CHAT_COMPLETIONS_DATABRICKS = "/serving-endpoints/{model_name}/invocations";
-  public static final String STABILITY_AI_GENERATE_IMAGES = "/v2beta/stable-image/generate/sd3";
-
-  public static final String MODERATIONS_PATH = "/moderations";
-
 
 }
 

--- a/src/main/java/com/mulesoft/connectors/inference/internal/dto/vision/Content.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/dto/vision/Content.java
@@ -3,7 +3,7 @@ package com.mulesoft.connectors.inference.internal.dto.vision;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(value = ImageContent.class, name = "image"),
     @JsonSubTypes.Type(value = TextContent.class, name = "text"),

--- a/src/main/java/com/mulesoft/connectors/inference/internal/helpers/McpHelper.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/helpers/McpHelper.java
@@ -27,7 +27,6 @@ import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -176,7 +175,7 @@ public class McpHelper {
         .orElse(new HashMap<>());
   }
 
-  private Map.@Nullable Entry<String, Property> getMapEntry(Map.Entry<String, Object> entry) {
+  private Map.Entry<String, Property> getMapEntry(Map.Entry<String, Object> entry) {
     Map<String, Object> propMap = convertToTypedMap((Map<?, ?>) entry.getValue());
     if (propMap == null) {
       return null;

--- a/src/main/java/com/mulesoft/connectors/inference/internal/helpers/response/HuggingFaceHttpResponseHelper.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/helpers/response/HuggingFaceHttpResponseHelper.java
@@ -2,6 +2,7 @@ package com.mulesoft.connectors.inference.internal.helpers.response;
 
 import org.mule.runtime.http.api.domain.message.response.HttpResponse;
 
+import com.mulesoft.connectors.inference.internal.constants.InferenceConstants;
 import com.mulesoft.connectors.inference.internal.dto.imagegeneration.HugginFaceImageRequestPayloadRecord;
 import com.mulesoft.connectors.inference.internal.dto.imagegeneration.ImageGenerationRequestPayloadDTO;
 import com.mulesoft.connectors.inference.internal.dto.imagegeneration.response.ImageData;
@@ -32,7 +33,7 @@ public class HuggingFaceHttpResponseHelper extends HttpResponseHelper {
     int statusCode = response.getStatusCode();
 
     if (statusCode == 200) {
-      if (StringUtils.isNotBlank(response.getHeaderValue("Content-Type")) &&
+      if (StringUtils.isNotBlank(response.getHeaderValue(InferenceConstants.HEADER_CONTENT_TYPE)) &&
           response.getHeaderValue("Content-Type").startsWith("image/")) {
 
         String base64Image = encodeImageToBase64(response.getEntity().getBytes());

--- a/src/main/java/com/mulesoft/connectors/inference/internal/helpers/response/HuggingFaceHttpResponseHelper.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/helpers/response/HuggingFaceHttpResponseHelper.java
@@ -2,7 +2,6 @@ package com.mulesoft.connectors.inference.internal.helpers.response;
 
 import org.mule.runtime.http.api.domain.message.response.HttpResponse;
 
-import com.mulesoft.connectors.inference.internal.constants.InferenceConstants;
 import com.mulesoft.connectors.inference.internal.dto.imagegeneration.HugginFaceImageRequestPayloadRecord;
 import com.mulesoft.connectors.inference.internal.dto.imagegeneration.ImageGenerationRequestPayloadDTO;
 import com.mulesoft.connectors.inference.internal.dto.imagegeneration.response.ImageData;
@@ -14,13 +13,8 @@ import java.util.Base64;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class HuggingFaceHttpResponseHelper extends HttpResponseHelper {
-
-  private static final Logger logger = LoggerFactory.getLogger(HuggingFaceHttpResponseHelper.class);
 
   public HuggingFaceHttpResponseHelper(ObjectMapper objectMapper) {
     super(objectMapper);
@@ -33,16 +27,11 @@ public class HuggingFaceHttpResponseHelper extends HttpResponseHelper {
     int statusCode = response.getStatusCode();
 
     if (statusCode == 200) {
-      if (StringUtils.isNotBlank(response.getHeaderValue(InferenceConstants.HEADER_CONTENT_TYPE)) &&
-          response.getHeaderValue("Content-Type").startsWith("image/")) {
+      String base64Image = encodeImageToBase64(response.getEntity().getBytes());
 
-        String base64Image = encodeImageToBase64(response.getEntity().getBytes());
+      HugginFaceImageRequestPayloadRecord payload = (HugginFaceImageRequestPayloadRecord) requestPayloadDTO;
 
-        HugginFaceImageRequestPayloadRecord payload = (HugginFaceImageRequestPayloadRecord) requestPayloadDTO;
-
-        return new ImageGenerationRestResponse(null, List.of(new ImageData(base64Image, payload.inputs())));
-      }
-      logger.debug("Response is not an image.");
+      return new ImageGenerationRestResponse(null, List.of(new ImageData(base64Image, payload.inputs())));
     }
     throw handleErrorResponse(response, statusCode, InferenceErrorType.IMAGE_GENERATION_FAILURE);
   }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/helpers/response/mapper/AnthropicResponseMapper.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/helpers/response/mapper/AnthropicResponseMapper.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +31,7 @@ public class AnthropicResponseMapper extends DefaultResponseMapper {
   public TextGenerationResponse mapChatResponse(TextResponseDTO responseDTO) {
     var chatCompletionResponse = (AnthropicChatCompletionResponse) responseDTO;
     var chatRespFirstChoice = chatCompletionResponse.content().stream()
-        .filter(x -> "text".equals(x.type()) && Strings.isNotBlank(x.text())).findFirst();
+        .filter(x -> "text".equals(x.type()) && StringUtils.isNotBlank(x.text())).findFirst();
     return new TextGenerationResponse(chatRespFirstChoice.map(Content::text).orElse(null),
                                       mapToolCalls(responseDTO), null);
   }

--- a/src/test/munit/chat-answer-prompt.xml
+++ b/src/test/munit/chat-answer-prompt.xml
@@ -180,7 +180,6 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 	<munit:test doc:id="b3144fa3-60d9-41f1-9c26-ab5eae501685" name="chat_answer_prompt_operation-Test">
 		<munit:execution>
 			<flow-ref doc:id="a79786d9-29f4-4966-996f-fef6f2abcfc7" doc:name="Flow-ref to chat_completion_operation" name="chat_answer_prompt_operation"/>
-			<!--<logger level="INFO" message="#[payload]"/>-->
 		</munit:execution>
 		<munit:validation>
 			<logger level="INFO" message="#[attributes]"/>

--- a/src/test/munit/config/anthropic-config.xml
+++ b/src/test/munit/config/anthropic-config.xml
@@ -23,7 +23,7 @@
     </mac-inference:text-generation-config>
 
     <!-- Vision Configuration -->
-    <mac-inference:vision-config name="AnthropicVision" doc:name="MuleSoft Inference Vision config" doc:id="13da78c8-3d61-468a-8fd0-629dda8c57ee" >
+    <mac-inference:vision-config name="AnthropicVisionConfig" doc:name="MuleSoft Inference Vision config" doc:id="13da78c8-3d61-468a-8fd0-629dda8c57ee" >
         <mac-inference:anthropic-vision-connection apiKey="${anthropic.apiKey}" anthropicModelName="${anthropic.llmModel}" />
     </mac-inference:vision-config>
 

--- a/src/test/munit/config/azure-ai-foundry-config.xml
+++ b/src/test/munit/config/azure-ai-foundry-config.xml
@@ -21,4 +21,10 @@
             </mac-inference:mcp-sse-servers>
         </mac-inference:azure-ai-foundry-connection>
     </mac-inference:text-generation-config>
+
+    <!-- Vision Configuration -->
+    <mac-inference:vision-config name="AzureAiFoundryVisionConfig" doc:name="MuleSoft Inference Vision config" doc:id="13da78c8-3d61-468a-8fd0-629dda8c57ee" >
+        <mac-inference:azure-ai-foundry-vision-connection apiKey="${azure-ai-foundry.apiKey}" azureAIFoundryModelName="${azure-ai-foundry.visionModel}" azureAIFoundryApiVersion="${azure-ai-foundry.apiVersion}" azureAIFoundryResourceName="${azure-ai-foundry.resource}"/>
+    </mac-inference:vision-config>
+
 </mule> 

--- a/src/test/munit/config/github-config.xml
+++ b/src/test/munit/config/github-config.xml
@@ -21,4 +21,10 @@
             </mac-inference:mcp-sse-servers>
         </mac-inference:github-connection>
     </mac-inference:text-generation-config>
+
+    <!-- Vision Configuration -->
+    <mac-inference:vision-config name="GithubVisionConfig" doc:name="MuleSoft Inference Vision config" doc:id="13da78c8-3d61-468a-8fd0-629dda8c57ee" >
+        <mac-inference:github-vision-connection apiKey="${github.apiKey}" gitHubModelName="${github.llmModel}" />
+    </mac-inference:vision-config>
+
 </mule> 

--- a/src/test/munit/config/hugging-face-config.xml
+++ b/src/test/munit/config/hugging-face-config.xml
@@ -22,6 +22,11 @@
         </mac-inference:hugging-face-connection>
     </mac-inference:text-generation-config>
 
+    <!-- Vision Configuration -->
+    <mac-inference:vision-config name="HuggingFaceVisionConfig" doc:name="MuleSoft Inference Vision config" doc:id="13da78c8-3d61-468a-8fd0-629dda8c57ee" >
+        <mac-inference:hugging-face-vision-connection apiKey="${hugging-face.apiKey}" huggingFaceModelName="${hugging-face.visionModel}" />
+    </mac-inference:vision-config>
+
     <!-- Image Generation Configuration -->
     <mac-inference:image-generation-config name="HuggingFaceImageGenConfig" doc:name="MuleSoft Inference Image generation config" doc:id="aba51427-1dd3-4915-a411-8fe6543ee6ac" >
         <mac-inference:hugging-face-image-connection apiKey="${hugging-face.apiKey}" huggingFaceModelName="${hugging-face.imageGenModel}" />

--- a/src/test/munit/config/hugging-face-config.xml
+++ b/src/test/munit/config/hugging-face-config.xml
@@ -22,4 +22,9 @@
         </mac-inference:hugging-face-connection>
     </mac-inference:text-generation-config>
 
+    <!-- Image Generation Configuration -->
+    <mac-inference:image-generation-config name="HuggingFaceImageGenConfig" doc:name="MuleSoft Inference Image generation config" doc:id="aba51427-1dd3-4915-a411-8fe6543ee6ac" >
+        <mac-inference:hugging-face-image-connection apiKey="${hugging-face.apiKey}" huggingFaceModelName="${hugging-face.imageGenModel}" />
+    </mac-inference:image-generation-config>
+
 </mule> 

--- a/src/test/munit/config/portkey-config.xml
+++ b/src/test/munit/config/portkey-config.xml
@@ -21,4 +21,10 @@
             </mac-inference:mcp-sse-servers>
         </mac-inference:portkey-connection>
     </mac-inference:text-generation-config>
+
+    <!-- Vision Configuration -->
+    <mac-inference:vision-config name="PortkeyVisionConfig" doc:name="MuleSoft Inference Vision config" doc:id="43158d4f-b08f-4ddc-8ff1-9865c406316e" >
+        <mac-inference:portkey-vision-connection apiKey="${portkey.apiKey}" portkeyModelName="${portkey.llmModel}" virtualKey="${portkey.virtualKey}"/>
+    </mac-inference:vision-config>
+    
 </mule>

--- a/src/test/munit/config/stabilityai-config.xml
+++ b/src/test/munit/config/stabilityai-config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:mac-inference="http://www.mulesoft.org/schema/mule/mac-inference"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+      xsi:schemaLocation="
+        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/mac-inference http://www.mulesoft.org/schema/mule/mac-inference/current/mule-mac-inference.xsd">
+
+    <configuration-properties file="automation-credentials.properties"/>
+
+    <!-- Image Generation Configuration -->
+    <mac-inference:image-generation-config name="StabilityAIImageGenConfig" doc:name="Stability AI Text generation config" doc:id="1ef66d01-d3ec-442a-bf61-99919d73f97e" >
+        <mac-inference:stability-ai-image-connection apiKey="${stability.apiKey}" stabilityAIModelName="${stability.imageGenModel}" timeout="60000"/>
+    </mac-inference:image-generation-config>
+</mule>

--- a/src/test/munit/config/xai-config.xml
+++ b/src/test/munit/config/xai-config.xml
@@ -21,4 +21,10 @@
             </mac-inference:mcp-sse-servers>
         </mac-inference:xai-connection>
     </mac-inference:text-generation-config>
+
+    <!-- Image Generation Configuration -->
+    <mac-inference:image-generation-config name="XAiImageGenConfig" doc:name="XAi Text generation config" doc:id="1ef66d01-d3ec-442a-bf61-99919d73f97e" >
+        <mac-inference:xai-image-connection apiKey="${xai.apiKey}" xAIModelName="${xai.imageGenModel}" timeout="60000"/>
+    </mac-inference:image-generation-config>
+    
 </mule>

--- a/src/test/munit/config/xai-config.xml
+++ b/src/test/munit/config/xai-config.xml
@@ -14,7 +14,7 @@
 
     <!-- Text Generation Configuration -->
     <mac-inference:text-generation-config name="XAiConfig" doc:name="xai Text generation config" doc:id="1ef66d01-d3ec-442a-bf61-99919d73f97e" >
-        <mac-inference:xai-connection apiKey="${xai.apiKey}" xaiModelName="${xai.llmModel}" timeout="60000">
+        <mac-inference:xai-connection apiKey="${xai.apiKey}" xAiModelName="${xai.llmModel}" timeout="60000">
             <mac-inference:mcp-sse-servers >
                 <mac-inference:mcp-sse-server key="ERP Server" value="http://mcp-server-demo-b2jb0y.1d6nel.usa-e1.cloudhub.io" />
                 <mac-inference:mcp-sse-server key="CRM Server" value="http://mcp-server-demo-crm-b2jb0y.1d6nel.usa-e1.cloudhub.io" />
@@ -24,7 +24,12 @@
 
     <!-- Image Generation Configuration -->
     <mac-inference:image-generation-config name="XAiImageGenConfig" doc:name="XAi Text generation config" doc:id="1ef66d01-d3ec-442a-bf61-99919d73f97e" >
-        <mac-inference:xai-image-connection apiKey="${xai.apiKey}" xAIModelName="${xai.imageGenModel}" timeout="60000"/>
+        <mac-inference:xai-image-connection apiKey="${xai.apiKey}" xAiModelName="${xai.imageGenModel}" timeout="60000"/>
     </mac-inference:image-generation-config>
+
+    <!-- Vision Configuration -->
+    <mac-inference:vision-config name="XAiVisionConfig" doc:name="MuleSoft Inference Vision config" doc:id="2ed49ebd-4050-4b0b-acc1-aba75096c78a" >
+        <mac-inference:xai-vision-connection apiKey="${xai.apiKey}" xAiModelName="${xai.visionModel}" />
+    </mac-inference:vision-config>
     
 </mule>

--- a/src/test/munit/generate-image.xml
+++ b/src/test/munit/generate-image.xml
@@ -11,6 +11,12 @@ http://www.mulesoft.org/schema/mule/mac-inference http://www.mulesoft.org/schema
 http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
 	<munit:config name="generate-image.xml" >
 		<munit:parameterizations >
+			<munit:parameterization name="hugging-face-config" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="HuggingFaceImageGenConfig" />
+					<munit:parameter propertyName="imageGenModel" value="${hugging-face.imageGenModel}" />
+				</munit:parameters>
+			</munit:parameterization>
 			<munit:parameterization name="openai-config" >
 				<munit:parameters >
 					<munit:parameter propertyName="config" value="OpenAIImageGen" />
@@ -21,6 +27,12 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 				<munit:parameters >
 					<munit:parameter propertyName="config" value="StabilityAIImageGenConfig" />
 					<munit:parameter propertyName="imageGenModel" value="${stability.imageGenModel}" />
+				</munit:parameters>
+			</munit:parameterization>
+			<munit:parameterization name="XAI-config" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="XAiImageGenConfig" />
+					<munit:parameter propertyName="imageGenModel" value="${xai.imageGenModel}" />
 				</munit:parameters>
 			</munit:parameterization>
 		</munit:parameterizations>

--- a/src/test/munit/generate-image.xml
+++ b/src/test/munit/generate-image.xml
@@ -17,16 +17,22 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<munit:parameter propertyName="imageGenModel" value="${openai.imageGenModel}" />
 				</munit:parameters>
 			</munit:parameterization>
+			<munit:parameterization name="stabilityai-config" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="StabilityAIImageGenConfig" />
+					<munit:parameter propertyName="imageGenModel" value="${stability.imageGenModel}" />
+				</munit:parameters>
+			</munit:parameterization>
 		</munit:parameterizations>
 	</munit:config>
 	<munit:test name="generate-image-operations-Test" doc:id="dd7abf89-e3c7-466f-8977-1209c1f69150" >
 		<munit:execution >
 			<flow-ref doc:name="Flow-ref to image-gen" doc:id="18071295-7596-44d3-ab7e-168f5d95a85d" name="generate-image-operation"/>
-			<logger level="DEBUG" doc:name="Logger" doc:id="288eb5f8-0683-46b8-baf5-53ce542d4885" message="#[payload]"/>
+			<!--<logger level="DEBUG" doc:name="Logger" doc:id="288eb5f8-0683-46b8-baf5-53ce542d4885" message="#[payload]"/>-->
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="payload.response" doc:id="82bcc94c-6021-485f-8c63-40b56a9524c5" message="Payload response is wrong answer" expression="#[payload.payload.response]" is="#[MunitTools::notNullValue()]" />
-			<munit-tools:assert-equals doc:name="model Info" doc:id="1eca8cf2-65ae-4bdc-8bf1-6aed45d3ab1f" actual="#[attributes.model]" expected="${openai.imageGenModel}" message="Incorrect Model Info" />
+			<munit-tools:assert-equals doc:name="model Info" doc:id="1eca8cf2-65ae-4bdc-8bf1-6aed45d3ab1f" actual="#[attributes.model]" expected="${imageGenModel}" message="Incorrect Model Info" />
 		</munit:validation>
 	</munit:test>
 	<sub-flow name="generate-image-operation" doc:id="3ff94cc9-278c-41f1-bafc-9da783016dd9" >

--- a/src/test/munit/providers/ImageModelNameValueProvidersTest.xml
+++ b/src/test/munit/providers/ImageModelNameValueProvidersTest.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns:mtf="http://www.mulesoft.org/schema/mule/mtf"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+        http://www.mulesoft.org/schema/mule/munit-tools http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        http://www.mulesoft.org/schema/mule/mtf http://www.mulesoft.org/schema/mule/mtf/current/mule-mtf.xsd">
+
+    <munit:config name="ImageModelNameValueProvidersTest.xml" />
+
+    <mtf:tooling-test name="openai-image-model-name-values-test">
+        <mtf:get-values-from-config config-ref="OpenAIImageGen" parameter="openAIModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(2)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="huggingface-image-model-name-values-test">
+        <mtf:get-values-from-config config-ref="HuggingFaceImageGenConfig" parameter="huggingFaceModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(3)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="xai-image-model-name-values-test">
+        <mtf:get-values-from-config config-ref="XAiImageGenConfig" parameter="xAIModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="stabilityai-image-model-name-values-test">
+        <mtf:get-values-from-config config-ref="StabilityAIImageGenConfig" parameter="stabilityAIModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(3)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+</mule> 

--- a/src/test/munit/providers/ImageModelNameValueProvidersTest.xml
+++ b/src/test/munit/providers/ImageModelNameValueProvidersTest.xml
@@ -12,13 +12,6 @@
 
     <munit:config name="ImageModelNameValueProvidersTest.xml" />
 
-    <mtf:tooling-test name="openai-image-model-name-values-test">
-        <mtf:get-values-from-config config-ref="OpenAIImageGen" parameter="openAIModelName"/>
-        <mtf:validation>
-            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(2)]"/>
-        </mtf:validation>
-    </mtf:tooling-test>
-
     <mtf:tooling-test name="huggingface-image-model-name-values-test">
         <mtf:get-values-from-config config-ref="HuggingFaceImageGenConfig" parameter="huggingFaceModelName"/>
         <mtf:validation>
@@ -26,10 +19,10 @@
         </mtf:validation>
     </mtf:tooling-test>
 
-    <mtf:tooling-test name="xai-image-model-name-values-test">
-        <mtf:get-values-from-config config-ref="XAiImageGenConfig" parameter="xAIModelName"/>
+    <mtf:tooling-test name="openai-image-model-name-values-test">
+        <mtf:get-values-from-config config-ref="OpenAIImageGen" parameter="openAIModelName"/>
         <mtf:validation>
-            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(2)]"/>
         </mtf:validation>
     </mtf:tooling-test>
 
@@ -40,4 +33,10 @@
         </mtf:validation>
     </mtf:tooling-test>
 
+    <mtf:tooling-test name="xai-image-model-name-values-test">
+        <mtf:get-values-from-config config-ref="XAiImageGenConfig" parameter="xAiModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
 </mule> 

--- a/src/test/munit/providers/ModelNameValueProvidersTest.xml
+++ b/src/test/munit/providers/ModelNameValueProvidersTest.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns:mtf="http://www.mulesoft.org/schema/mule/mtf"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+        http://www.mulesoft.org/schema/mule/munit-tools http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        http://www.mulesoft.org/schema/mule/mtf http://www.mulesoft.org/schema/mule/mtf/current/mule-mtf.xsd">
+
+    <munit:config name="ModelNameValueProvidersTest.xml"/>
+
+    <mtf:tooling-test name="anthropic-model-name-values-test">
+        <mtf:get-values-from-config config-ref="AnthropicConfig" parameter="anthropicModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(4)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="azure-ai-foundry-model-name-values-test">
+        <mtf:get-values-from-config config-ref="azureAiFoundryConfig" parameter="azureModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(2)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="azure-openai-model-name-values-test">
+        <mtf:get-values-from-config config-ref="AzureOpenAIConfig" parameter="azureModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="cerebras-model-name-values-test">
+        <mtf:get-values-from-config config-ref="CerebrasConfig" parameter="cerebrasModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(2)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="cohere-model-name-values-test">
+        <mtf:get-values-from-config config-ref="CohereConfig" parameter="cohereModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(6)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="deepinfra-model-name-values-test">
+        <mtf:get-values-from-config config-ref="DeepinfraConfig" parameter="deepInfraModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+   <!-- <mtf:tooling-test name="deepseek-model-name-values-test">
+        <mtf:get-values-from-config config-ref="DeepseekConfig" parameter="deepseekModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>-->
+
+    <mtf:tooling-test name="fireworks-model-name-values-test">
+        <mtf:get-values-from-config config-ref="FireworksConfig" parameter="fireworksModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="github-model-name-values-test">
+        <mtf:get-values-from-config config-ref="GithubConfig" parameter="gitHubModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(7)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="groq-model-name-values-test">
+        <mtf:get-values-from-config config-ref="GroqConfig" parameter="groqModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(17)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="huggingface-model-name-values-test">
+        <mtf:get-values-from-config config-ref="HuggingFaceConfig" parameter="huggingFaceModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(4)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="llmapi-model-name-values-test">
+        <mtf:get-values-from-config config-ref="llmapiConfig" parameter="llmApiModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="mistralai-model-name-values-test">
+        <mtf:get-values-from-config config-ref="MistralAIConfig" parameter="mistralAIModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(4)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="nvidia-model-name-values-test">
+        <mtf:get-values-from-config config-ref="NvidiaConfig" parameter="nvidiaModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(2)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="openaicompatible-model-name-values-test">
+        <mtf:get-values-from-config config-ref="OpenAICompatibleConfig" parameter="openAICompatibleModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(5)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="openai-model-name-values-test">
+        <mtf:get-values-from-config config-ref="OpenAIConfig" parameter="openAIModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(5)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="openrouter-model-name-values-test">
+        <mtf:get-values-from-config config-ref="OpenrouterConfig" parameter="openRouterModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(32)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="portkey-model-name-values-test">
+        <mtf:get-values-from-config config-ref="PortkeyConfig" parameter="portkeyModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(9)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="together-model-name-values-test">
+        <mtf:get-values-from-config config-ref="TogetherConfig" parameter="togetherModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="xai-model-name-values-test">
+        <mtf:get-values-from-config config-ref="XAiConfig" parameter="xaiModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(4)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <!--<mtf:tooling-test name="xinference-model-name-values-test">
+        <mtf:get-values-from-config config-ref="XInferenceConfig" parameter="xInferenceModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(5)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>-->
+
+    <mtf:tooling-test name="zhipu-model-name-values-test">
+        <mtf:get-values-from-config config-ref="ZhipuConfig" parameter="zhipuAIModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(2)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+</mule>

--- a/src/test/munit/providers/ModerationModelNameValueProvidersTest.xml
+++ b/src/test/munit/providers/ModerationModelNameValueProvidersTest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns:mtf="http://www.mulesoft.org/schema/mule/mtf"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+        http://www.mulesoft.org/schema/mule/munit-tools http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        http://www.mulesoft.org/schema/mule/mtf http://www.mulesoft.org/schema/mule/mtf/current/mule-mtf.xsd">
+
+    <munit:config name="ModerationModelNameValueProvidersTest.xml"/>
+
+    <mtf:tooling-test name="openai-moderation-model-name-values-test">
+        <mtf:get-values-from-config config-ref="OpenAIModeration" parameter="openAIModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(2)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="mistralai-moderation-model-name-values-test">
+        <mtf:get-values-from-config config-ref="MistralAIModeration" parameter="mistralAIModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+</mule> 

--- a/src/test/munit/providers/TextGenerationModelNameValueProvidersTest.xml
+++ b/src/test/munit/providers/TextGenerationModelNameValueProvidersTest.xml
@@ -10,7 +10,7 @@
         http://www.mulesoft.org/schema/mule/munit-tools http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
         http://www.mulesoft.org/schema/mule/mtf http://www.mulesoft.org/schema/mule/mtf/current/mule-mtf.xsd">
 
-    <munit:config name="ModelNameValueProvidersTest.xml"/>
+    <munit:config name="TextGenerationModelNameValueProvidersTest.xml"/>
 
     <mtf:tooling-test name="anthropic-model-name-values-test">
         <mtf:get-values-from-config config-ref="AnthropicConfig" parameter="anthropicModelName"/>
@@ -146,7 +146,7 @@
     </mtf:tooling-test>
 
     <mtf:tooling-test name="xai-model-name-values-test">
-        <mtf:get-values-from-config config-ref="XAiConfig" parameter="xaiModelName"/>
+        <mtf:get-values-from-config config-ref="XAiConfig" parameter="xAiModelName"/>
         <mtf:validation>
             <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(4)]"/>
         </mtf:validation>

--- a/src/test/munit/providers/VisionModelNameValueProvidersTest.xml
+++ b/src/test/munit/providers/VisionModelNameValueProvidersTest.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns:mtf="http://www.mulesoft.org/schema/mule/mtf"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+        http://www.mulesoft.org/schema/mule/munit-tools http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        http://www.mulesoft.org/schema/mule/mtf http://www.mulesoft.org/schema/mule/mtf/current/mule-mtf.xsd">
+
+    <munit:config name="VisionModelNameValueProvidersTest.xml"/>
+
+    <mtf:tooling-test name="anthropic-vision-model-name-values-test">
+        <mtf:get-values-from-config config-ref="AnthropicVisionConfig" parameter="anthropicModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(4)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="azure-ai-foundry-vision-model-name-values-test">
+        <mtf:get-values-from-config config-ref="AzureAiFoundryVisionConfig" parameter="azureAIFoundryModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(2)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="github-vision-model-name-values-test">
+        <mtf:get-values-from-config config-ref="GithubVisionConfig" parameter="gitHubModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(4)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <!--<mtf:tooling-test name="groq-vision-model-name-values-test">
+        <mtf:get-values-from-config config-ref="GroqVisionConfig" parameter="groqModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>-->
+
+    <mtf:tooling-test name="huggingface-vision-model-name-values-test">
+        <mtf:get-values-from-config config-ref="HuggingFaceVisionConfig" parameter="huggingFaceModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(4)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="mistralai-vision-model-name-values-test">
+        <mtf:get-values-from-config config-ref="MistralAIVision" parameter="mistralAIModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(3)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="openai-vision-model-name-values-test">
+        <mtf:get-values-from-config config-ref="OpenAIVision" parameter="openAIModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(5)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="openrouter-vision-model-name-values-test">
+        <mtf:get-values-from-config config-ref="OpenrouterVision" parameter="openRouterModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(5)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="portkey-vision-model-name-values-test">
+        <mtf:get-values-from-config config-ref="PortkeyVisionConfig" parameter="portkeyModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(1)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+
+    <mtf:tooling-test name="xai-vision-model-name-values-test">
+        <mtf:get-values-from-config config-ref="XAiVisionConfig" parameter="xAiModelName"/>
+        <mtf:validation>
+            <munit-tools:assert-that expression="#[sizeOf(payload)]" is="#[MunitTools::equalTo(2)]"/>
+        </mtf:validation>
+    </mtf:tooling-test>
+</mule>

--- a/src/test/munit/read-image-base64.xml
+++ b/src/test/munit/read-image-base64.xml
@@ -4,10 +4,26 @@
 		<munit:parameterizations >
 			<munit:parameterization name="config-anthropic" >
 				<munit:parameters >
-					<munit:parameter propertyName="config" value="AnthropicVision" />
+					<munit:parameter propertyName="config" value="AnthropicVisionConfig" />
 					<munit:parameter propertyName="llmModel" value="${anthropic.llmModel}" />
 					<munit:parameter propertyName="inputCount" value="56" />
 					<munit:parameter propertyName="finishReason" value="end_turn" />
+				</munit:parameters>
+			</munit:parameterization>
+			<munit:parameterization name="config-azure-ai-foundry" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="AzureAiFoundryVisionConfig" />
+					<munit:parameter propertyName="llmModel" value="${azure-ai-foundry.visionModelResponse}" />
+					<munit:parameter propertyName="inputCount" value="771" />
+					<munit:parameter propertyName="finishReason" value="stop" />
+				</munit:parameters>
+			</munit:parameterization>
+			<munit:parameterization name="config-github" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="GithubVisionConfig" />
+					<munit:parameter propertyName="llmModel" value="${github.visionModelResponse}" />
+					<munit:parameter propertyName="inputCount" value="360" />
+					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>
 			<munit:parameterization name="config-mistralai" >
@@ -43,11 +59,18 @@
 			<!--<logger level="INFO" message="#[payload]"/>-->
 		</munit:execution>
 		<munit:validation>
-			<munit-tools:assert-that doc:id="e45fe6bd-e51a-40e6-9c18-e1cc92295832" doc:name="red in payload" expression="#[payload.payload.response]" is="#[MunitTools::containsString('red')]" message="Payload response is wrong answer"/>
-			<munit-tools:assert-that doc:name="car in payload" doc:id="1c9a0319-420e-4194-a0a1-6e8d21f28782" message="Payload response is wrong answer" expression="#[payload.payload.response]" is="#[MunitTools::containsString('car')]" />
-			<munit-tools:assert-equals actual="#[attributes.tokenUsage.inputCount as String]" doc:id="b125348b-26d7-4388-9c88-4dfc6351d22a" doc:name="Input Token" expected="${inputCount}" message="Incorrect Input Token"/>
-			<munit-tools:assert-equals actual="#[attributes.additionalAttributes.model]" doc:id="ba201df7-81f2-4404-baee-755c49b3a20f" doc:name="model Info" expected="${llmModel}" message="Incorrect Model Info"/>
-			<munit-tools:assert-equals actual="#[attributes.additionalAttributes.finishReason]" doc:id="a2b27c93-45b9-4373-91e7-e7838cf6e9f2" doc:name="finish reason" expected="${finishReason}" message="Incorrect finish reason"/>
+			<munit-tools:assert-that doc:id="e45fe6bd-e51a-40e6-9c18-e1cc92295832" doc:name="red in payload"
+									 expression="#[payload.payload.response]"
+									 is="#[MunitTools::containsString('red')]" message="Payload response is wrong answer"/>
+			<munit-tools:assert-that doc:name="car in payload" doc:id="1c9a0319-420e-4194-a0a1-6e8d21f28782" message="Payload response is wrong answer"
+									 expression="#[payload.payload.response]"
+									 is="#[MunitTools::either(MunitTools::containsString('car'), MunitTools::containsString('Toyota'))]" />
+			<munit-tools:assert-equals actual="#[attributes.tokenUsage.inputCount as String]" doc:id="b125348b-26d7-4388-9c88-4dfc6351d22a" doc:name="Input Token"
+									   expected="${inputCount}" message="Incorrect Input Token"/>
+			<munit-tools:assert-equals actual="#[attributes.additionalAttributes.model]" doc:id="ba201df7-81f2-4404-baee-755c49b3a20f" doc:name="model Info"
+									   expected="${llmModel}" message="Incorrect Model Info"/>
+			<munit-tools:assert-equals actual="#[attributes.additionalAttributes.finishReason]" doc:id="a2b27c93-45b9-4373-91e7-e7838cf6e9f2" doc:name="finish reason"
+									   expected="${finishReason}" message="Incorrect finish reason"/>
 		</munit:validation>
 	</munit:test>
 

--- a/src/test/munit/read-image-base64.xml
+++ b/src/test/munit/read-image-base64.xml
@@ -26,6 +26,14 @@
 					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>
+			<munit:parameterization name="config-hugging-face" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="HuggingFaceVisionConfig" />
+					<munit:parameter propertyName="llmModel" value="${hugging-face.visionModel}" />
+					<munit:parameter propertyName="inputCount" value="41" />
+					<munit:parameter propertyName="finishReason" value="stop" />
+				</munit:parameters>
+			</munit:parameterization>
 			<munit:parameterization name="config-mistralai" >
 				<munit:parameters >
 					<munit:parameter propertyName="config" value="MistralAIVision" />
@@ -47,6 +55,14 @@
 					<munit:parameter propertyName="config" value="OpenrouterVision" />
 					<munit:parameter propertyName="llmModel" value="${openrouter.visionModel}" />
 					<munit:parameter propertyName="inputCount" value="15" />
+					<munit:parameter propertyName="finishReason" value="stop" />
+				</munit:parameters>
+			</munit:parameterization>
+			<munit:parameterization name="config-portkey" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="PortkeyVisionConfig" />
+					<munit:parameter propertyName="llmModel" value="${portkey.llmModel}" />
+					<munit:parameter propertyName="inputCount" value="55" />
 					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>

--- a/src/test/munit/read-image-base64.xml
+++ b/src/test/munit/read-image-base64.xml
@@ -66,6 +66,14 @@
 					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>
+			<munit:parameterization name="config-xai" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="XAiVisionConfig" />
+					<munit:parameter propertyName="llmModel" value="${xai.visionModel}" />
+					<munit:parameter propertyName="inputCount" value="267" />
+					<munit:parameter propertyName="finishReason" value="stop" />
+				</munit:parameters>
+			</munit:parameterization>
 		</munit:parameterizations>
 	</munit:config>
 

--- a/src/test/munit/read-image-base64.xml
+++ b/src/test/munit/read-image-base64.xml
@@ -22,7 +22,7 @@
 				<munit:parameters >
 					<munit:parameter propertyName="config" value="GithubVisionConfig" />
 					<munit:parameter propertyName="llmModel" value="${github.visionModelResponse}" />
-					<munit:parameter propertyName="inputCount" value="360" />
+					<munit:parameter propertyName="inputCount" value="221" />
 					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>

--- a/src/test/munit/read-image-url.xml
+++ b/src/test/munit/read-image-url.xml
@@ -4,10 +4,26 @@
 		<munit:parameterizations>
 			<munit:parameterization name="config-anthropic" >
 				<munit:parameters >
-					<munit:parameter propertyName="config" value="AnthropicVision" />
+					<munit:parameter propertyName="config" value="AnthropicVisionConfig" />
 					<munit:parameter propertyName="llmModel" value="${anthropic.llmModel}" />
 					<munit:parameter propertyName="inputCount" value="439" />
 					<munit:parameter propertyName="finishReason" value="end_turn" />
+				</munit:parameters>
+			</munit:parameterization>
+			<munit:parameterization name="config-azure-ai-foundry" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="AzureAiFoundryVisionConfig" />
+					<munit:parameter propertyName="llmModel" value="${azure-ai-foundry.visionModelResponse}" />
+					<munit:parameter propertyName="inputCount" value="771" />
+					<munit:parameter propertyName="finishReason" value="stop" />
+				</munit:parameters>
+			</munit:parameterization>
+			<munit:parameterization name="config-github" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="GithubVisionConfig" />
+					<munit:parameter propertyName="llmModel" value="${github.visionModelResponse}" />
+					<munit:parameter propertyName="inputCount" value="360" />
+					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>
 			<munit:parameterization name="config-mistralai" >

--- a/src/test/munit/read-image-url.xml
+++ b/src/test/munit/read-image-url.xml
@@ -66,6 +66,14 @@
 					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>
+			<munit:parameterization name="config-xai" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="XAiVisionConfig" />
+					<munit:parameter propertyName="llmModel" value="${xai.visionModel}" />
+					<munit:parameter propertyName="inputCount" value="267" />
+					<munit:parameter propertyName="finishReason" value="stop" />
+				</munit:parameters>
+			</munit:parameterization>
 		</munit:parameterizations>
 	</munit:config>
 

--- a/src/test/munit/read-image-url.xml
+++ b/src/test/munit/read-image-url.xml
@@ -26,6 +26,14 @@
 					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>
+			<munit:parameterization name="config-hugging-face" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="HuggingFaceVisionConfig" />
+					<munit:parameter propertyName="llmModel" value="${hugging-face.visionModel}" />
+					<munit:parameter propertyName="inputCount" value="41" />
+					<munit:parameter propertyName="finishReason" value="stop" />
+				</munit:parameters>
+			</munit:parameterization>
 			<munit:parameterization name="config-mistralai" >
 				<munit:parameters >
 					<munit:parameter propertyName="config" value="MistralAIVision" />
@@ -47,6 +55,14 @@
 					<munit:parameter propertyName="config" value="OpenrouterVision" />
 					<munit:parameter propertyName="llmModel" value="${openrouter.visionModel}" />
 					<munit:parameter propertyName="inputCount" value="15" />
+					<munit:parameter propertyName="finishReason" value="stop" />
+				</munit:parameters>
+			</munit:parameterization>
+			<munit:parameterization name="config-portkey" >
+				<munit:parameters >
+					<munit:parameter propertyName="config" value="PortkeyVisionConfig" />
+					<munit:parameter propertyName="llmModel" value="${portkey.llmModel}" />
+					<munit:parameter propertyName="inputCount" value="449" />
 					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>

--- a/src/test/munit/tools-native-template-llm-response.xml
+++ b/src/test/munit/tools-native-template-llm-response.xml
@@ -1,5 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xmlns:mac-inference="http://www.mulesoft.org/schema/mule/mac-inference" xmlns:munit="http://www.mulesoft.org/schema/mule/munit" xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="         http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd         http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd         http://www.mulesoft.org/schema/mule/munit-tools http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd         http://www.mulesoft.org/schema/mule/mac-inference http://www.mulesoft.org/schema/mule/mac-inference/current/mule-mac-inference.xsd         http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xmlns:mac-inference="http://www.mulesoft.org/schema/mule/mac-inference" xmlns:munit="http://www.mulesoft.org/schema/mule/munit" xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="         http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd         http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd         http://www.mulesoft.org/schema/mule/munit-tools http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd         http://www.mulesoft.org/schema/mule/mac-inference http://www.mulesoft.org/schema/mule/mac-inference/current/mule-mac-inference.xsd         http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
 
+	<!-- This test is used to test the LLM capability to answer questions that are not part of provided functions.
+	Note: Not all LLMs have this capability and therefore not all inference types will be covered as part of this test
+	-->
 	<munit:config name="tools-native-template-llm-response.xml">
 		<munit:parameterizations>
 			<munit:parameterization name="config-anthropic" >
@@ -50,14 +54,6 @@
 					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>
-			<munit:parameterization name="config-fireworks" >
-				<munit:parameters >
-					<munit:parameter propertyName="config" value="FireworksConfig" />
-					<munit:parameter propertyName="llmModel" value="${fireworks.llmModel}" />
-					<munit:parameter propertyName="inputCount" value="462" />
-					<munit:parameter propertyName="finishReason" value="stop" />
-				</munit:parameters>
-			</munit:parameterization>
 			<munit:parameterization name="config-github" >
 				<munit:parameters >
 					<munit:parameter propertyName="config" value="GithubConfig" />
@@ -79,14 +75,6 @@
 					<munit:parameter propertyName="config" value="HuggingFaceConfig" />
 					<munit:parameter propertyName="llmModel" value="${hugging-face.llmModel}" />
 					<munit:parameter propertyName="inputCount" value="24" />
-					<munit:parameter propertyName="finishReason" value="stop" />
-				</munit:parameters>
-			</munit:parameterization>
-			<munit:parameterization name="config-llmapi" >
-				<munit:parameters >
-					<munit:parameter propertyName="config" value="llmapiConfig" />
-					<munit:parameter propertyName="llmModel" value="${llmapi.llmModel}" />
-					<munit:parameter propertyName="inputCount" value="53" />
 					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>
@@ -138,23 +126,6 @@
 					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>
-<!--		Fix issues with these - to be analysed further on difference in responses
-			<munit:parameterization name="config-together" >
-				<munit:parameters >
-					<munit:parameter propertyName="config" value="TogetherConfig" />
-					<munit:parameter propertyName="llmModel" value="${together.llmModel}" />
-					<munit:parameter propertyName="inputCount" value="53" />
-					<munit:parameter propertyName="finishReason" value="stop" />
-				</munit:parameters>
-			</munit:parameterization>
-			<munit:parameterization name="config-xai" >
-				<munit:parameters >
-					<munit:parameter propertyName="config" value="XAiConfig" />
-					<munit:parameter propertyName="llmModel" value="${xai.llmModel}" />
-					<munit:parameter propertyName="inputCount" value="24" />
-					<munit:parameter propertyName="finishReason" value="stop" />
-				</munit:parameters>
-			</munit:parameterization>-->
 			<munit:parameterization name="config-zhipu" >
 				<munit:parameters >
 					<munit:parameter propertyName="config" value="ZhipuConfig" />

--- a/src/test/munit/tools-native-template-llm-response.xml
+++ b/src/test/munit/tools-native-template-llm-response.xml
@@ -54,7 +54,7 @@
 				<munit:parameters >
 					<munit:parameter propertyName="config" value="FireworksConfig" />
 					<munit:parameter propertyName="llmModel" value="${fireworks.llmModel}" />
-					<munit:parameter propertyName="inputCount" value="466" />
+					<munit:parameter propertyName="inputCount" value="462" />
 					<munit:parameter propertyName="finishReason" value="stop" />
 				</munit:parameters>
 			</munit:parameterization>


### PR DESCRIPTION
Changes:
- Add missing dependency and code cleanup
- Remove LLMs from _tools-native-template-llm-response.xml_ which do not have capability of answering both generic questions and using functions/tools
- Add tests for :
    - Value provider for model names for text generation connection
    - Value provider for model names for image generation connection
    - Value provider for model names for moderation connection
    - Stability AI image gen operation
    - Hugging face image gen operation
    - XAI image gen operation
    - Azure Foundry vision operation
    - Github vision operation
    - Huggingface vision operation
    - Portkey vision operation
    - xai vision operation
   