### PR TITLE
Add custom header support for all operations

### DIFF
--- a/src/main/java/com/mulesoft/connectors/inference/api/request/KeyValue.java
+++ b/src/main/java/com/mulesoft/connectors/inference/api/request/KeyValue.java
@@ -1,0 +1,38 @@
+package com.mulesoft.connectors.inference.api.request;
+
+import static org.mule.runtime.api.meta.ExpressionSupport.NOT_SUPPORTED;
+
+import org.mule.runtime.extension.api.annotation.Expression;
+import org.mule.runtime.extension.api.annotation.param.Parameter;
+
+/**
+ * Abstract class to represent a key-value such as headerName-headerValue. Can be later used with query params as well
+ */
+public abstract class KeyValue {
+
+  @Parameter
+  @Expression(NOT_SUPPORTED)
+  private String key;
+
+  @Parameter
+  @Expression(NOT_SUPPORTED)
+  private String value;
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+}
+

--- a/src/main/java/com/mulesoft/connectors/inference/api/request/RequestHeader.java
+++ b/src/main/java/com/mulesoft/connectors/inference/api/request/RequestHeader.java
@@ -1,0 +1,24 @@
+package com.mulesoft.connectors.inference.api.request;
+
+import org.mule.runtime.extension.api.annotation.Alias;
+
+/**
+ * Represents an HTTP Header
+ */
+@Alias("defaultHeader")
+public class RequestHeader extends KeyValue {
+
+  public RequestHeader() {
+    // default constructor
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+}

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/parameters/BaseConnectionParameters.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/parameters/BaseConnectionParameters.java
@@ -4,11 +4,16 @@ import static org.mule.runtime.extension.api.annotation.param.display.Placement.
 
 import org.mule.runtime.api.meta.ExpressionSupport;
 import org.mule.runtime.extension.api.annotation.Expression;
+import org.mule.runtime.extension.api.annotation.param.NullSafe;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
 import org.mule.runtime.extension.api.annotation.param.display.Placement;
+import org.mule.runtime.extension.api.annotation.param.display.Summary;
 
+import com.mulesoft.connectors.inference.api.request.RequestHeader;
+
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class BaseConnectionParameters {
@@ -22,6 +27,17 @@ public class BaseConnectionParameters {
   @DisplayName("API Key")
   @Placement(order = 1)
   private String apiKey;
+
+  /**
+   * Custom HTTP headers the requests should include.
+   */
+  @Parameter
+  @Optional
+  @NullSafe
+  @DisplayName("Custom headers")
+  @Summary("Custom headers that can be included in every single request sent.")
+  @Placement(order = 2)
+  private List<RequestHeader> customHeaders;
 
   /**
    * The response timeout value set for each inference HTTP request
@@ -43,6 +59,10 @@ public class BaseConnectionParameters {
 
   public String getApiKey() {
     return apiKey;
+  }
+
+  public List<RequestHeader> getCustomHeaders() {
+    return customHeaders;
   }
 
   public int getTimeout() {

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/ai21labs/AI21LabsTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/ai21labs/AI21LabsTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class AI21LabsTextGenerationConnectionProvider extends TextGenerationConn
                                                                   textGenerationConnectionParameters.getMaxTokens(),
                                                                   textGenerationConnectionParameters.getTemperature(),
                                                                   textGenerationConnectionParameters.getTopP(),
-                                                                  textGenerationConnectionParameters.getTimeout()));
+                                                                  textGenerationConnectionParameters.getTimeout(),
+                                                                  textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/anthropic/AnthropicTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/anthropic/AnthropicTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class AnthropicTextGenerationConnectionProvider extends TextGenerationCon
                                                                    textGenerationConnectionParameters.getMaxTokens(),
                                                                    textGenerationConnectionParameters.getTemperature(),
                                                                    textGenerationConnectionParameters.getTopP(),
-                                                                   textGenerationConnectionParameters.getTimeout()));
+                                                                   textGenerationConnectionParameters.getTimeout(),
+                                                                   textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/anthropic/AnthropicVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/anthropic/AnthropicVisionConnectionProvider.java
@@ -48,6 +48,8 @@ public class AnthropicVisionConnectionProvider extends VisionModelConnectionProv
                                                                                                visionConnectionParameters
                                                                                                    .getTopP(),
                                                                                                visionConnectionParameters
-                                                                                                   .getTimeout()));
+                                                                                                   .getTimeout(),
+                                                                                               visionConnectionParameters
+                                                                                                   .getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/azure/AzureAIFoundryTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/azure/AzureAIFoundryTextGenerationConnectionProvider.java
@@ -58,7 +58,8 @@ public class AzureAIFoundryTextGenerationConnectionProvider extends TextGenerati
                                                                         textGenerationConnectionParameters.getMaxTokens(),
                                                                         textGenerationConnectionParameters.getTemperature(),
                                                                         textGenerationConnectionParameters.getTopP(),
-                                                                        textGenerationConnectionParameters.getTimeout()),
+                                                                        textGenerationConnectionParameters.getTimeout(),
+                                                                        textGenerationConnectionParameters.getCustomHeaders()),
                                                       azureAIFoundryResourceName, azureAIFoundryApiVersion);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/azure/AzureAIFoundryVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/azure/AzureAIFoundryVisionConnectionProvider.java
@@ -64,7 +64,9 @@ public class AzureAIFoundryVisionConnectionProvider extends VisionModelConnectio
                                                                 visionConnectionParameters
                                                                     .getTopP(),
                                                                 visionConnectionParameters
-                                                                    .getTimeout()),
+                                                                    .getTimeout(),
+                                                                visionConnectionParameters
+                                                                    .getCustomHeaders()),
                                               azureAIFoundryResourceName, azureAIFoundryApiVersion);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/azure/AzureOpenAITextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/azure/AzureOpenAITextGenerationConnectionProvider.java
@@ -68,7 +68,8 @@ public class AzureOpenAITextGenerationConnectionProvider extends TextGenerationC
                                                                      textGenerationConnectionParameters.getMaxTokens(),
                                                                      textGenerationConnectionParameters.getTemperature(),
                                                                      textGenerationConnectionParameters.getTopP(),
-                                                                     textGenerationConnectionParameters.getTimeout()),
+                                                                     textGenerationConnectionParameters.getTimeout(),
+                                                                     textGenerationConnectionParameters.getCustomHeaders()),
                                                    azureOpenaiResourceName, azureOpenaiDeploymentId, azureOpenaiUser);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/cerebras/CerebrasTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/cerebras/CerebrasTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class CerebrasTextGenerationConnectionProvider extends TextGenerationConn
                                                                   textGenerationConnectionParameters.getMaxTokens(),
                                                                   textGenerationConnectionParameters.getTemperature(),
                                                                   textGenerationConnectionParameters.getTopP(),
-                                                                  textGenerationConnectionParameters.getTimeout()));
+                                                                  textGenerationConnectionParameters.getTimeout(),
+                                                                  textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/cohere/CohereTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/cohere/CohereTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class CohereTextGenerationConnectionProvider extends TextGenerationConnec
                                                                 textGenerationConnectionParameters.getMaxTokens(),
                                                                 textGenerationConnectionParameters.getTemperature(),
                                                                 textGenerationConnectionParameters.getTopP(),
-                                                                textGenerationConnectionParameters.getTimeout()));
+                                                                textGenerationConnectionParameters.getTimeout(),
+                                                                textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/databricks/DatabricksTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/databricks/DatabricksTextGenerationConnectionProvider.java
@@ -50,7 +50,8 @@ public class DatabricksTextGenerationConnectionProvider extends TextGenerationCo
                                                                     textGenerationConnectionParameters.getMaxTokens(),
                                                                     textGenerationConnectionParameters.getTemperature(),
                                                                     textGenerationConnectionParameters.getTopP(),
-                                                                    textGenerationConnectionParameters.getTimeout()),
+                                                                    textGenerationConnectionParameters.getTimeout(),
+                                                                    textGenerationConnectionParameters.getCustomHeaders()),
                                                   servingEndpointUrlHost);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/deepinfra/DeepInfraTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/deepinfra/DeepInfraTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class DeepInfraTextGenerationConnectionProvider extends TextGenerationCon
                                                                    textGenerationConnectionParameters.getMaxTokens(),
                                                                    textGenerationConnectionParameters.getTemperature(),
                                                                    textGenerationConnectionParameters.getTopP(),
-                                                                   textGenerationConnectionParameters.getTimeout()));
+                                                                   textGenerationConnectionParameters.getTimeout(),
+                                                                   textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/deepseek/DeepseekTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/deepseek/DeepseekTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class DeepseekTextGenerationConnectionProvider extends TextGenerationConn
                                                                   textGenerationConnectionParameters.getMaxTokens(),
                                                                   textGenerationConnectionParameters.getTemperature(),
                                                                   textGenerationConnectionParameters.getTopP(),
-                                                                  textGenerationConnectionParameters.getTimeout()));
+                                                                  textGenerationConnectionParameters.getTimeout(),
+                                                                  textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/docker/DockerTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/docker/DockerTextGenerationConnectionProvider.java
@@ -51,7 +51,8 @@ public class DockerTextGenerationConnectionProvider extends TextGenerationConnec
                                                                 textGenerationConnectionParameters.getMaxTokens(),
                                                                 textGenerationConnectionParameters.getTemperature(),
                                                                 textGenerationConnectionParameters.getTopP(),
-                                                                textGenerationConnectionParameters.getTimeout()),
+                                                                textGenerationConnectionParameters.getTimeout(),
+                                                                textGenerationConnectionParameters.getCustomHeaders()),
                                               dockerModelUrl);
 
   }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/fireworks/FireworksTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/fireworks/FireworksTextGenerationConnectionProvider.java
@@ -43,7 +43,8 @@ public class FireworksTextGenerationConnectionProvider extends TextGenerationCon
                                                                    textGenerationConnectionParameters.getMaxTokens(),
                                                                    textGenerationConnectionParameters.getTemperature(),
                                                                    textGenerationConnectionParameters.getTopP(),
-                                                                   textGenerationConnectionParameters.getTimeout()));
+                                                                   textGenerationConnectionParameters.getTimeout(),
+                                                                   textGenerationConnectionParameters.getCustomHeaders()));
 
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/github/GithubTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/github/GithubTextGenerationConnectionProvider.java
@@ -43,7 +43,8 @@ public class GithubTextGenerationConnectionProvider extends TextGenerationConnec
                                                                 textGenerationConnectionParameters.getMaxTokens(),
                                                                 textGenerationConnectionParameters.getTemperature(),
                                                                 textGenerationConnectionParameters.getTopP(),
-                                                                textGenerationConnectionParameters.getTimeout()));
+                                                                textGenerationConnectionParameters.getTimeout(),
+                                                                textGenerationConnectionParameters.getCustomHeaders()));
 
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/github/GithubVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/github/GithubVisionConnectionProvider.java
@@ -48,6 +48,8 @@ public class GithubVisionConnectionProvider extends VisionModelConnectionProvide
                                                                                             textGenerationConnectionParameters
                                                                                                 .getTopP(),
                                                                                             textGenerationConnectionParameters
-                                                                                                .getTimeout()));
+                                                                                                .getTimeout(),
+                                                                                            textGenerationConnectionParameters
+                                                                                                .getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/gpt4all/GPT4AllTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/gpt4all/GPT4AllTextGenerationConnectionProvider.java
@@ -52,7 +52,8 @@ public class GPT4AllTextGenerationConnectionProvider extends TextGenerationConne
                                                                  textGenerationConnectionParameters.getMaxTokens(),
                                                                  textGenerationConnectionParameters.getTemperature(),
                                                                  textGenerationConnectionParameters.getTopP(),
-                                                                 textGenerationConnectionParameters.getTimeout()),
+                                                                 textGenerationConnectionParameters.getTimeout(),
+                                                                 textGenerationConnectionParameters.getCustomHeaders()),
                                                gpt4AllBaseURL);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/groq/GroqTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/groq/GroqTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class GroqTextGenerationConnectionProvider extends TextGenerationConnecti
                                                               textGenerationConnectionParameters.getMaxTokens(),
                                                               textGenerationConnectionParameters.getTemperature(),
                                                               textGenerationConnectionParameters.getTopP(),
-                                                              textGenerationConnectionParameters.getTimeout()));
+                                                              textGenerationConnectionParameters.getTimeout(),
+                                                              textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/groq/GroqVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/groq/GroqVisionConnectionProvider.java
@@ -48,6 +48,8 @@ public class GroqVisionConnectionProvider extends VisionModelConnectionProvider 
                                                                                           textGenerationConnectionParameters
                                                                                               .getTopP(),
                                                                                           textGenerationConnectionParameters
-                                                                                              .getTimeout()));
+                                                                                              .getTimeout(),
+                                                                                          textGenerationConnectionParameters
+                                                                                              .getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/heroku/HerokuImageGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/heroku/HerokuImageGenerationConnectionProvider.java
@@ -47,7 +47,7 @@ public class HerokuImageGenerationConnectionProvider extends ImageGenerationConn
     logger.debug("ImageGenerationConnection connect ...");
 
     return new HerokuImageGenerationConnection(getHttpClient(), getObjectMapper(), herokuInferenceModel,
-                                               baseConnectionParameters.getApiKey(),
+                                               baseConnectionParameters.getApiKey(), baseConnectionParameters.getCustomHeaders(),
                                                baseConnectionParameters.getTimeout(),
                                                getImageGenerationAPIURL(herokuDiffusionUrl));
   }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/heroku/HerokuTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/heroku/HerokuTextGenerationConnectionProvider.java
@@ -53,7 +53,8 @@ public class HerokuTextGenerationConnectionProvider extends TextGenerationConnec
                                                                 herokuTextGenerationConnectionParameters
                                                                     .getTemperature(),
                                                                 herokuTextGenerationConnectionParameters.getTopP(),
-                                                                herokuTextGenerationConnectionParameters.getTimeout()),
+                                                                herokuTextGenerationConnectionParameters.getTimeout(),
+                                                                herokuTextGenerationConnectionParameters.getCustomHeaders()),
                                               herokuInferenceUrl);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/huggingface/HuggingFaceImageConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/huggingface/HuggingFaceImageConnectionProvider.java
@@ -41,6 +41,7 @@ public class HuggingFaceImageConnectionProvider extends ImageGenerationConnectio
 
     return new HuggingFaceImageGenerationConnection(getHttpClient(), getObjectMapper(), huggingFaceModelName,
                                                     baseConnectionParameters.getApiKey(),
+                                                    baseConnectionParameters.getCustomHeaders(),
                                                     baseConnectionParameters.getTimeout(),
                                                     getImageGenerationAPIURL(huggingFaceModelName));
   }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/huggingface/HuggingFaceTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/huggingface/HuggingFaceTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class HuggingFaceTextGenerationConnectionProvider extends TextGenerationC
                                                                      textGenerationConnectionParameters.getMaxTokens(),
                                                                      textGenerationConnectionParameters.getTemperature(),
                                                                      textGenerationConnectionParameters.getTopP(),
-                                                                     textGenerationConnectionParameters.getTimeout()));
+                                                                     textGenerationConnectionParameters.getTimeout(),
+                                                                     textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/huggingface/HuggingFaceVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/huggingface/HuggingFaceVisionConnectionProvider.java
@@ -48,6 +48,8 @@ public class HuggingFaceVisionConnectionProvider extends VisionModelConnectionPr
                                                                                                  textGenerationConnectionParameters
                                                                                                      .getTopP(),
                                                                                                  textGenerationConnectionParameters
-                                                                                                     .getTimeout()));
+                                                                                                     .getTimeout(),
+                                                                                                 textGenerationConnectionParameters
+                                                                                                     .getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/lmstudio/LMStudioTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/lmstudio/LMStudioTextGenerationConnectionProvider.java
@@ -52,7 +52,8 @@ public class LMStudioTextGenerationConnectionProvider extends TextGenerationConn
                                                                   textGenerationConnectionParameters.getMaxTokens(),
                                                                   textGenerationConnectionParameters.getTemperature(),
                                                                   textGenerationConnectionParameters.getTopP(),
-                                                                  textGenerationConnectionParameters.getTimeout()),
+                                                                  textGenerationConnectionParameters.getTimeout(),
+                                                                  textGenerationConnectionParameters.getCustomHeaders()),
                                                 lmStudioBaseURL);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/mistralai/MistralAIModerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/mistralai/MistralAIModerationConnectionProvider.java
@@ -40,6 +40,7 @@ public class MistralAIModerationConnectionProvider extends ModerationConnectionP
     logger.debug("ModerationConnection connect ...");
 
     return new ModerationConnection(getHttpClient(), getObjectMapper(), baseConnectionParameters.getApiKey(),
+                                    baseConnectionParameters.getCustomHeaders(),
                                     mistralAIModelName, baseConnectionParameters.getTimeout(), getModerationAPIURL());
   }
 

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/mistralai/MistralAITextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/mistralai/MistralAITextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class MistralAITextGenerationConnectionProvider extends TextGenerationCon
                                                                    textGenerationConnectionParameters.getMaxTokens(),
                                                                    textGenerationConnectionParameters.getTemperature(),
                                                                    textGenerationConnectionParameters.getTopP(),
-                                                                   textGenerationConnectionParameters.getTimeout()));
+                                                                   textGenerationConnectionParameters.getTimeout(),
+                                                                   textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/mistralai/MistralAIVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/mistralai/MistralAIVisionConnectionProvider.java
@@ -48,6 +48,8 @@ public class MistralAIVisionConnectionProvider extends VisionModelConnectionProv
                                                                                                visionConnectionParameters
                                                                                                    .getTopP(),
                                                                                                visionConnectionParameters
-                                                                                                   .getTimeout()));
+                                                                                                   .getTimeout(),
+                                                                                               visionConnectionParameters
+                                                                                                   .getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/nvidia/NvidiaTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/nvidia/NvidiaTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class NvidiaTextGenerationConnectionProvider extends TextGenerationConnec
                                                                 textGenerationConnectionParameters.getMaxTokens(),
                                                                 textGenerationConnectionParameters.getTemperature(),
                                                                 textGenerationConnectionParameters.getTopP(),
-                                                                textGenerationConnectionParameters.getTimeout()));
+                                                                textGenerationConnectionParameters.getTimeout(),
+                                                                textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/ollama/OllamaTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/ollama/OllamaTextGenerationConnectionProvider.java
@@ -51,7 +51,8 @@ public class OllamaTextGenerationConnectionProvider extends TextGenerationConnec
                                                                 textGenerationConnectionParameters.getMaxTokens(),
                                                                 textGenerationConnectionParameters.getTemperature(),
                                                                 textGenerationConnectionParameters.getTopP(),
-                                                                textGenerationConnectionParameters.getTimeout()),
+                                                                textGenerationConnectionParameters.getTimeout(),
+                                                                textGenerationConnectionParameters.getCustomHeaders()),
                                               ollamaUrl);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/ollama/OllamaVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/ollama/OllamaVisionConnectionProvider.java
@@ -56,7 +56,9 @@ public class OllamaVisionConnectionProvider extends VisionModelConnectionProvide
                                                                                             textGenerationConnectionParameters
                                                                                                 .getTopP(),
                                                                                             textGenerationConnectionParameters
-                                                                                                .getTimeout()),
+                                                                                                .getTimeout(),
+                                                                                            textGenerationConnectionParameters
+                                                                                                .getCustomHeaders()),
                                       ollamaUrl);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openai/OpenAIImageGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openai/OpenAIImageGenerationConnectionProvider.java
@@ -40,7 +40,7 @@ public class OpenAIImageGenerationConnectionProvider extends ImageGenerationConn
     logger.debug("ImageGenerationConnection connect ...");
 
     return new OpenAIImageGenerationConnection(getHttpClient(), getObjectMapper(), openAIModelName,
-                                               baseConnectionParameters.getApiKey(),
+                                               baseConnectionParameters.getApiKey(), baseConnectionParameters.getCustomHeaders(),
                                                baseConnectionParameters.getTimeout(), getImageGenerationAPIURL());
   }
 

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openai/OpenAIModerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openai/OpenAIModerationConnectionProvider.java
@@ -39,7 +39,8 @@ public class OpenAIModerationConnectionProvider extends ModerationConnectionProv
   public ModerationConnection connect() {
     logger.debug("ModerationConnection connect ...");
 
-    return new ModerationConnection(getHttpClient(), getObjectMapper(), baseConnectionParameters.getApiKey(), openAIModelName,
+    return new ModerationConnection(getHttpClient(), getObjectMapper(), baseConnectionParameters.getApiKey(),
+                                    baseConnectionParameters.getCustomHeaders(), openAIModelName,
                                     baseConnectionParameters.getTimeout(), getModerationAPIURL());
   }
 

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openai/OpenAITextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openai/OpenAITextGenerationConnectionProvider.java
@@ -45,6 +45,7 @@ public class OpenAITextGenerationConnectionProvider extends TextGenerationConnec
                                                                 openAITextGenerationConnectionParameters.getMaxTokens(),
                                                                 openAITextGenerationConnectionParameters.getTemperature(),
                                                                 openAITextGenerationConnectionParameters.getTopP(),
-                                                                openAITextGenerationConnectionParameters.getTimeout()));
+                                                                openAITextGenerationConnectionParameters.getTimeout(),
+                                                                openAITextGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openai/OpenAIVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openai/OpenAIVisionConnectionProvider.java
@@ -47,6 +47,8 @@ public class OpenAIVisionConnectionProvider extends VisionModelConnectionProvide
                                                                                                 .getTemperature(),
                                                                                             visionConnectionParameters.getTopP(),
                                                                                             visionConnectionParameters
-                                                                                                .getTimeout()));
+                                                                                                .getTimeout(),
+                                                                                            visionConnectionParameters
+                                                                                                .getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openaicompatible/OpenAICompatibleTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openaicompatible/OpenAICompatibleTextGenerationConnectionProvider.java
@@ -55,7 +55,9 @@ public class OpenAICompatibleTextGenerationConnectionProvider extends TextGenera
                                                                           openAITextGenerationConnectionParameters
                                                                               .getTemperature(),
                                                                           openAITextGenerationConnectionParameters.getTopP(),
-                                                                          openAITextGenerationConnectionParameters.getTimeout()),
+                                                                          openAITextGenerationConnectionParameters.getTimeout(),
+                                                                          openAITextGenerationConnectionParameters
+                                                                              .getCustomHeaders()),
                                                         openAICompatibleURL);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openrouter/OpenRouterTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openrouter/OpenRouterTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class OpenRouterTextGenerationConnectionProvider extends TextGenerationCo
                                                                     textGenerationConnectionParameters.getMaxTokens(),
                                                                     textGenerationConnectionParameters.getTemperature(),
                                                                     textGenerationConnectionParameters.getTopP(),
-                                                                    textGenerationConnectionParameters.getTimeout()));
+                                                                    textGenerationConnectionParameters.getTimeout(),
+                                                                    textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openrouter/OpenRouterVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/openrouter/OpenRouterVisionConnectionProvider.java
@@ -48,6 +48,8 @@ public class OpenRouterVisionConnectionProvider extends VisionModelConnectionPro
                                                                                                 visionConnectionParameters
                                                                                                     .getTopP(),
                                                                                                 visionConnectionParameters
-                                                                                                    .getTimeout()));
+                                                                                                    .getTimeout(),
+                                                                                                visionConnectionParameters
+                                                                                                    .getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/perplexity/PerplexityTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/perplexity/PerplexityTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class PerplexityTextGenerationConnectionProvider extends TextGenerationCo
                                                                     textGenerationConnectionParameters.getMaxTokens(),
                                                                     textGenerationConnectionParameters.getTemperature(),
                                                                     textGenerationConnectionParameters.getTopP(),
-                                                                    textGenerationConnectionParameters.getTimeout()));
+                                                                    textGenerationConnectionParameters.getTimeout(),
+                                                                    textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/portkey/PortkeyTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/portkey/PortkeyTextGenerationConnectionProvider.java
@@ -51,7 +51,8 @@ public class PortkeyTextGenerationConnectionProvider extends TextGenerationConne
                                                                  textGenerationConnectionParameters.getMaxTokens(),
                                                                  textGenerationConnectionParameters.getTemperature(),
                                                                  textGenerationConnectionParameters.getTopP(),
-                                                                 textGenerationConnectionParameters.getTimeout()),
+                                                                 textGenerationConnectionParameters.getTimeout(),
+                                                                 textGenerationConnectionParameters.getCustomHeaders()),
                                                virtualKey);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/portkey/PortkeyVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/portkey/PortkeyVisionConnectionProvider.java
@@ -56,7 +56,9 @@ public class PortkeyVisionConnectionProvider extends VisionModelConnectionProvid
                                                                                              textGenerationConnectionParameters
                                                                                                  .getTopP(),
                                                                                              textGenerationConnectionParameters
-                                                                                                 .getTimeout()),
+                                                                                                 .getTimeout(),
+                                                                                             textGenerationConnectionParameters
+                                                                                                 .getCustomHeaders()),
                                        virtualKey);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/stabilityai/StabilityAIImageConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/stabilityai/StabilityAIImageConnectionProvider.java
@@ -41,6 +41,7 @@ public class StabilityAIImageConnectionProvider extends ImageGenerationConnectio
 
     return new StabilityAIImageGenerationConnection(getHttpClient(), getObjectMapper(), stabilityAIModelName,
                                                     baseConnectionParameters.getApiKey(),
+                                                    baseConnectionParameters.getCustomHeaders(),
                                                     baseConnectionParameters.getTimeout(), getImageGenerationAPIURL());
   }
 

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/together/TogetherTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/together/TogetherTextGenerationConnectionProvider.java
@@ -37,6 +37,7 @@ public class TogetherTextGenerationConnectionProvider extends TextGenerationConn
                                                                   textGenerationConnectionParameters.getMaxTokens(),
                                                                   textGenerationConnectionParameters.getTemperature(),
                                                                   textGenerationConnectionParameters.getTopP(),
-                                                                  textGenerationConnectionParameters.getTimeout()));
+                                                                  textGenerationConnectionParameters.getTimeout(),
+                                                                  textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/vertexai/VertexAIExpressTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/vertexai/VertexAIExpressTextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class VertexAIExpressTextGenerationConnectionProvider extends TextGenerat
                                                                          textGenerationConnectionParameters.getMaxTokens(),
                                                                          textGenerationConnectionParameters.getTemperature(),
                                                                          textGenerationConnectionParameters.getTopP(),
-                                                                         textGenerationConnectionParameters.getTimeout()));
+                                                                         textGenerationConnectionParameters.getTimeout(),
+                                                                         textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/vertexai/VertexAIExpressVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/vertexai/VertexAIExpressVisionConnectionProvider.java
@@ -48,6 +48,8 @@ public class VertexAIExpressVisionConnectionProvider extends VisionModelConnecti
                                                                                                      textGenerationConnectionParameters
                                                                                                          .getTopP(),
                                                                                                      textGenerationConnectionParameters
-                                                                                                         .getTimeout()));
+                                                                                                         .getTimeout(),
+                                                                                                     textGenerationConnectionParameters
+                                                                                                         .getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAIImageConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAIImageConnectionProvider.java
@@ -40,7 +40,7 @@ public class XAIImageConnectionProvider extends ImageGenerationConnectionProvide
     logger.debug("XAIImageConnection connect ...");
 
     return new XAIImageGenerationConnection(getHttpClient(), getObjectMapper(), xAiModelName,
-                                            baseConnectionParameters.getApiKey(),
+                                            baseConnectionParameters.getApiKey(), baseConnectionParameters.getCustomHeaders(),
                                             baseConnectionParameters.getTimeout(), getImageGenerationAPIURL());
   }
 

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAITextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAITextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class XAITextGenerationConnectionProvider extends TextGenerationConnectio
                                                              textGenerationConnectionParameters.getMaxTokens(),
                                                              textGenerationConnectionParameters.getTemperature(),
                                                              textGenerationConnectionParameters.getTopP(),
-                                                             textGenerationConnectionParameters.getTimeout()));
+                                                             textGenerationConnectionParameters.getTimeout(),
+                                                             textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAIVisionConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xai/XAIVisionConnectionProvider.java
@@ -48,6 +48,8 @@ public class XAIVisionConnectionProvider extends VisionModelConnectionProvider {
                                                                                          textGenerationConnectionParameters
                                                                                              .getTopP(),
                                                                                          textGenerationConnectionParameters
-                                                                                             .getTimeout()));
+                                                                                             .getTimeout(),
+                                                                                         textGenerationConnectionParameters
+                                                                                             .getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xinference/XInferenceTextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/xinference/XInferenceTextGenerationConnectionProvider.java
@@ -51,7 +51,8 @@ public class XInferenceTextGenerationConnectionProvider extends TextGenerationCo
                                                                     textGenerationConnectionParameters.getMaxTokens(),
                                                                     textGenerationConnectionParameters.getTemperature(),
                                                                     textGenerationConnectionParameters.getTopP(),
-                                                                    textGenerationConnectionParameters.getTimeout()),
+                                                                    textGenerationConnectionParameters.getTimeout(),
+                                                                    textGenerationConnectionParameters.getCustomHeaders()),
                                                   xInferenceUrl);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/zhipuai/ZhipuAITextGenerationConnectionProvider.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/provider/zhipuai/ZhipuAITextGenerationConnectionProvider.java
@@ -43,6 +43,7 @@ public class ZhipuAITextGenerationConnectionProvider extends TextGenerationConne
                                                                  textGenerationConnectionParameters.getMaxTokens(),
                                                                  textGenerationConnectionParameters.getTemperature(),
                                                                  textGenerationConnectionParameters.getTopP(),
-                                                                 textGenerationConnectionParameters.getTimeout()));
+                                                                 textGenerationConnectionParameters.getTimeout(),
+                                                                 textGenerationConnectionParameters.getCustomHeaders()));
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/ImageGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/ImageGenerationConnection.java
@@ -2,7 +2,10 @@ package com.mulesoft.connectors.inference.internal.connection.types;
 
 import org.mule.runtime.http.api.client.HttpClient;
 
+import com.mulesoft.connectors.inference.api.request.RequestHeader;
 import com.mulesoft.connectors.inference.internal.service.ImageGenerationService;
+
+import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -11,8 +14,8 @@ public class ImageGenerationConnection extends BaseConnection {
   private ImageGenerationService imageGenerationService;
 
   public ImageGenerationConnection(HttpClient httpClient, ObjectMapper objectMapper, String modelName, String apiKey,
-                                   int timeout, String apiURL) {
-    super(httpClient, objectMapper, modelName, apiKey, timeout, apiURL);
+                                   List<RequestHeader> customHeaders, int timeout, String apiURL) {
+    super(httpClient, objectMapper, modelName, apiKey, customHeaders, timeout, apiURL);
     this.setBaseService(getImageGenerationService());
   }
 

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/ModerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/ModerationConnection.java
@@ -2,7 +2,10 @@ package com.mulesoft.connectors.inference.internal.connection.types;
 
 import org.mule.runtime.http.api.client.HttpClient;
 
+import com.mulesoft.connectors.inference.api.request.RequestHeader;
 import com.mulesoft.connectors.inference.internal.service.ModerationService;
+
+import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -11,9 +14,9 @@ public class ModerationConnection extends BaseConnection {
   private ModerationService moderationService;
 
   public ModerationConnection(HttpClient httpClient, ObjectMapper objectMapper,
-                              String apiKey, String modelName, int timeout,
+                              String apiKey, List<RequestHeader> customHeaders, String modelName, int timeout,
                               String apiURL) {
-    super(httpClient, objectMapper, modelName, apiKey, timeout, apiURL);
+    super(httpClient, objectMapper, modelName, apiKey, customHeaders, timeout, apiURL);
     this.setBaseService(getModerationService());
   }
 

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/TextGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/TextGenerationConnection.java
@@ -16,7 +16,7 @@ public abstract class TextGenerationConnection extends BaseConnection {
 
   protected TextGenerationConnection(HttpClient httpClient, ObjectMapper objectMapper, ParametersDTO parametersDTO,
                                      String apiURL) {
-    super(httpClient, objectMapper, parametersDTO.modelName(), parametersDTO.apiKey(),
+    super(httpClient, objectMapper, parametersDTO.modelName(), parametersDTO.apiKey(), parametersDTO.customHeaders(),
           parametersDTO.timeout(), apiURL);
     this.maxTokens = parametersDTO.maxTokens();
     this.temperature = parametersDTO.temperature();

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/VisionModelConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/VisionModelConnection.java
@@ -16,7 +16,7 @@ public class VisionModelConnection extends BaseConnection {
   private VisionModelService visionModelService;
 
   protected VisionModelConnection(HttpClient httpClient, ObjectMapper objectMapper, ParametersDTO parametersDTO, String apiUrl) {
-    super(httpClient, objectMapper, parametersDTO.modelName(), parametersDTO.apiKey(),
+    super(httpClient, objectMapper, parametersDTO.modelName(), parametersDTO.apiKey(), parametersDTO.customHeaders(),
           parametersDTO.timeout(), apiUrl);
     this.maxTokens = parametersDTO.maxTokens();
     this.temperature = parametersDTO.temperature();

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/anthropic/AnthropicTextGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/anthropic/AnthropicTextGenerationConnection.java
@@ -8,6 +8,7 @@ import com.mulesoft.connectors.inference.internal.helpers.payload.AnthropicReque
 import com.mulesoft.connectors.inference.internal.helpers.response.AnthropicHttpResponseHelper;
 import com.mulesoft.connectors.inference.internal.helpers.response.mapper.AnthropicResponseMapper;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,7 +49,13 @@ public class AnthropicTextGenerationConnection extends TextGenerationConnection 
 
   @Override
   public Map<String, String> getAdditionalHeaders() {
-    return Map.of("x-api-key", this.getApiKey(), "anthropic-version", "2023-06-01");
+
+    Map<String, String> headers = new HashMap<>();
+
+    headers.put("x-api-key", this.getApiKey());
+    headers.put("anthropic-version", "2023-06-01");
+    headers.putAll(getCustomHeadersMap());
+    return headers;
   }
 
   private static String fetchApiURL() {

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/anthropic/AnthropicVisionConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/anthropic/AnthropicVisionConnection.java
@@ -8,6 +8,7 @@ import com.mulesoft.connectors.inference.internal.helpers.payload.AnthropicReque
 import com.mulesoft.connectors.inference.internal.helpers.response.AnthropicHttpResponseHelper;
 import com.mulesoft.connectors.inference.internal.helpers.response.mapper.AnthropicResponseMapper;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -49,7 +50,12 @@ public class AnthropicVisionConnection extends VisionModelConnection {
 
   @Override
   public Map<String, String> getAdditionalHeaders() {
-    return Map.of("x-api-key", this.getApiKey(), "anthropic-version", "2023-06-01");
+    Map<String, String> headers = new HashMap<>();
+
+    headers.put("x-api-key", this.getApiKey());
+    headers.put("anthropic-version", "2023-06-01");
+    headers.putAll(getCustomHeadersMap());
+    return headers;
   }
 
   private static String fetchApiURL() {

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/azure/AzureAIFoundryTextGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/azure/AzureAIFoundryTextGenerationConnection.java
@@ -5,6 +5,7 @@ import org.mule.runtime.http.api.client.HttpClient;
 import com.mulesoft.connectors.inference.internal.connection.types.TextGenerationConnection;
 import com.mulesoft.connectors.inference.internal.dto.ParametersDTO;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,7 +24,11 @@ public class AzureAIFoundryTextGenerationConnection extends TextGenerationConnec
 
   @Override
   public Map<String, String> getAdditionalHeaders() {
-    return Map.of("api-key", this.getApiKey());
+    Map<String, String> headers = new HashMap<>();
+
+    headers.put("api-key", this.getApiKey());
+    headers.putAll(getCustomHeadersMap());
+    return headers;
   }
 
   private static String fetchApiURL(String azureAIFoundryResourceName, String azureAIFoundryApiVersion) {

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/azure/AzureOpenAITextGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/azure/AzureOpenAITextGenerationConnection.java
@@ -6,6 +6,7 @@ import com.mulesoft.connectors.inference.internal.connection.types.TextGeneratio
 import com.mulesoft.connectors.inference.internal.dto.ParametersDTO;
 import com.mulesoft.connectors.inference.internal.helpers.payload.AzureOpenAIRequestPayloadHelper;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,7 +37,11 @@ public class AzureOpenAITextGenerationConnection extends TextGenerationConnectio
 
   @Override
   public Map<String, String> getAdditionalHeaders() {
-    return Map.of("api-key", this.getApiKey());
+    Map<String, String> headers = new HashMap<>();
+
+    headers.put("api-key", this.getApiKey());
+    headers.putAll(getCustomHeadersMap());
+    return headers;
   }
 
   private static String fetchApiURL(String openaiResourceName, String openaiDeploymentId) {

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/heroku/HerokuImageGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/heroku/HerokuImageGenerationConnection.java
@@ -2,14 +2,17 @@ package com.mulesoft.connectors.inference.internal.connection.types.heroku;
 
 import org.mule.runtime.http.api.client.HttpClient;
 
+import com.mulesoft.connectors.inference.api.request.RequestHeader;
 import com.mulesoft.connectors.inference.internal.connection.types.ImageGenerationConnection;
+
+import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class HerokuImageGenerationConnection extends ImageGenerationConnection {
 
   public HerokuImageGenerationConnection(HttpClient httpClient, ObjectMapper objectMapper, String modelName, String apiKey,
-                                         int timeout, String apiURL) {
-    super(httpClient, objectMapper, modelName, apiKey, timeout, apiURL);
+                                         List<RequestHeader> customHeaders, int timeout, String apiURL) {
+    super(httpClient, objectMapper, modelName, apiKey, customHeaders, timeout, apiURL);
   }
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/huggingface/HuggingFaceImageGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/huggingface/HuggingFaceImageGenerationConnection.java
@@ -2,9 +2,12 @@ package com.mulesoft.connectors.inference.internal.connection.types.huggingface;
 
 import org.mule.runtime.http.api.client.HttpClient;
 
+import com.mulesoft.connectors.inference.api.request.RequestHeader;
 import com.mulesoft.connectors.inference.internal.connection.types.ImageGenerationConnection;
 import com.mulesoft.connectors.inference.internal.helpers.payload.HuggingFaceRequestPayloadHelper;
 import com.mulesoft.connectors.inference.internal.helpers.response.HuggingFaceHttpResponseHelper;
+
+import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -13,8 +16,8 @@ public class HuggingFaceImageGenerationConnection extends ImageGenerationConnect
   private HuggingFaceRequestPayloadHelper requestPayloadHelper;
 
   public HuggingFaceImageGenerationConnection(HttpClient httpClient, ObjectMapper objectMapper, String modelName, String apiKey,
-                                              int timeout, String apiURL) {
-    super(httpClient, objectMapper, modelName, apiKey, timeout, apiURL);
+                                              List<RequestHeader> customHeaders, int timeout, String apiURL) {
+    super(httpClient, objectMapper, modelName, apiKey, customHeaders, timeout, apiURL);
   }
 
   @Override

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/openai/OpenAIImageGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/openai/OpenAIImageGenerationConnection.java
@@ -2,8 +2,11 @@ package com.mulesoft.connectors.inference.internal.connection.types.openai;
 
 import org.mule.runtime.http.api.client.HttpClient;
 
+import com.mulesoft.connectors.inference.api.request.RequestHeader;
 import com.mulesoft.connectors.inference.internal.connection.types.ImageGenerationConnection;
 import com.mulesoft.connectors.inference.internal.helpers.payload.OpenAIRequestPayloadHelper;
+
+import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -11,9 +14,10 @@ public class OpenAIImageGenerationConnection extends ImageGenerationConnection {
 
   private OpenAIRequestPayloadHelper requestPayloadHelper;
 
-  public OpenAIImageGenerationConnection(HttpClient httpClient, ObjectMapper objectMapper, String modelName, String apiKey,
+  public OpenAIImageGenerationConnection(HttpClient httpClient, ObjectMapper objectMapper, String modelName,
+                                         String apiKey, List<RequestHeader> customHeaders,
                                          int timeout, String apiURL) {
-    super(httpClient, objectMapper, modelName, apiKey, timeout, apiURL);
+    super(httpClient, objectMapper, modelName, apiKey, customHeaders, timeout, apiURL);
   }
 
   @Override

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/portkey/PortkeyTextGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/portkey/PortkeyTextGenerationConnection.java
@@ -5,6 +5,7 @@ import org.mule.runtime.http.api.client.HttpClient;
 import com.mulesoft.connectors.inference.internal.connection.types.TextGenerationConnection;
 import com.mulesoft.connectors.inference.internal.dto.ParametersDTO;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,7 +25,12 @@ public class PortkeyTextGenerationConnection extends TextGenerationConnection {
 
   @Override
   public Map<String, String> getAdditionalHeaders() {
-    return Map.of("x-portkey-api-key", this.getApiKey(), "x-portkey-virtual-key", this.virtualKey);
+    Map<String, String> headers = new HashMap<>();
+
+    headers.put("x-portkey-api-key", this.getApiKey());
+    headers.put("x-portkey-virtual-key", this.virtualKey);
+    headers.putAll(getCustomHeadersMap());
+    return headers;
   }
 
   private static String fetchApiURL() {

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/portkey/PortkeyVisionConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/portkey/PortkeyVisionConnection.java
@@ -5,6 +5,7 @@ import org.mule.runtime.http.api.client.HttpClient;
 import com.mulesoft.connectors.inference.internal.connection.types.VisionModelConnection;
 import com.mulesoft.connectors.inference.internal.dto.ParametersDTO;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,7 +24,12 @@ public class PortkeyVisionConnection extends VisionModelConnection {
 
   @Override
   public Map<String, String> getAdditionalHeaders() {
-    return Map.of("x-portkey-api-key", this.getApiKey(), "x-portkey-virtual-key", this.virtualKey);
+    Map<String, String> headers = new HashMap<>();
+
+    headers.put("x-portkey-api-key", this.getApiKey());
+    headers.put("x-portkey-virtual-key", this.virtualKey);
+    headers.putAll(getCustomHeadersMap());
+    return headers;
   }
 
   private static String fetchApiURL() {

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/stabilityai/StabilityAIImageGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/stabilityai/StabilityAIImageGenerationConnection.java
@@ -2,10 +2,13 @@ package com.mulesoft.connectors.inference.internal.connection.types.stabilityai;
 
 import org.mule.runtime.http.api.client.HttpClient;
 
+import com.mulesoft.connectors.inference.api.request.RequestHeader;
 import com.mulesoft.connectors.inference.internal.connection.types.ImageGenerationConnection;
 import com.mulesoft.connectors.inference.internal.helpers.payload.StabilityAIRequestPayloadHelper;
 import com.mulesoft.connectors.inference.internal.helpers.request.StabilityAIHttpRequestHelper;
 import com.mulesoft.connectors.inference.internal.helpers.response.StabilityAIHttpResponseHelper;
+
+import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -14,8 +17,8 @@ public class StabilityAIImageGenerationConnection extends ImageGenerationConnect
   private StabilityAIRequestPayloadHelper requestPayloadHelper;
 
   public StabilityAIImageGenerationConnection(HttpClient httpClient, ObjectMapper objectMapper, String modelName, String apiKey,
-                                              int timeout, String apiURL) {
-    super(httpClient, objectMapper, modelName, apiKey, timeout, apiURL);
+                                              List<RequestHeader> customHeaders, int timeout, String apiURL) {
+    super(httpClient, objectMapper, modelName, apiKey, customHeaders, timeout, apiURL);
   }
 
   @Override

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/vertexai/VertexAIExpressTextGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/vertexai/VertexAIExpressTextGenerationConnection.java
@@ -8,7 +8,6 @@ import com.mulesoft.connectors.inference.internal.helpers.payload.VertexAIReques
 import com.mulesoft.connectors.inference.internal.helpers.response.VertexAIHttpResponseHelper;
 import com.mulesoft.connectors.inference.internal.helpers.response.mapper.VertexAIResponseMapper;
 
-import java.util.Collections;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,7 +55,7 @@ public class VertexAIExpressTextGenerationConnection extends TextGenerationConne
 
   @Override
   public Map<String, String> getAdditionalHeaders() {
-    return Collections.emptyMap();
+    return getCustomHeadersMap();
   }
 
   private static String fetchApiURL(String modelName) {

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/vertexai/VertexAIExpressVisionConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/vertexai/VertexAIExpressVisionConnection.java
@@ -8,7 +8,6 @@ import com.mulesoft.connectors.inference.internal.helpers.payload.VertexAIReques
 import com.mulesoft.connectors.inference.internal.helpers.response.VertexAIHttpResponseHelper;
 import com.mulesoft.connectors.inference.internal.helpers.response.mapper.VertexAIResponseMapper;
 
-import java.util.Collections;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,7 +54,7 @@ public class VertexAIExpressVisionConnection extends VisionModelConnection {
 
   @Override
   public Map<String, String> getAdditionalHeaders() {
-    return Collections.emptyMap();
+    return getCustomHeadersMap();
   }
 
   private static String fetchApiURL(String modelName) {

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/xai/XAIImageGenerationConnection.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/types/xai/XAIImageGenerationConnection.java
@@ -2,15 +2,18 @@ package com.mulesoft.connectors.inference.internal.connection.types.xai;
 
 import org.mule.runtime.http.api.client.HttpClient;
 
+import com.mulesoft.connectors.inference.api.request.RequestHeader;
 import com.mulesoft.connectors.inference.internal.connection.types.ImageGenerationConnection;
+
+import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class XAIImageGenerationConnection extends ImageGenerationConnection {
 
   public XAIImageGenerationConnection(HttpClient httpClient, ObjectMapper objectMapper, String modelName, String apiKey,
-                                      int timeout, String apiURL) {
-    super(httpClient, objectMapper, modelName, apiKey, timeout, apiURL);
+                                      List<RequestHeader> customHeaders, int timeout, String apiURL) {
+    super(httpClient, objectMapper, modelName, apiKey, customHeaders, timeout, apiURL);
   }
 
 }

--- a/src/main/java/com/mulesoft/connectors/inference/internal/dto/ParametersDTO.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/dto/ParametersDTO.java
@@ -1,3 +1,9 @@
 package com.mulesoft.connectors.inference.internal.dto;
 
-public record ParametersDTO(String modelName,String apiKey,Number maxTokens,Number temperature,Number topP,int timeout){}
+import com.mulesoft.connectors.inference.api.request.RequestHeader;
+
+import java.util.List;
+
+public record ParametersDTO(String modelName,String apiKey,Number maxTokens,Number temperature,Number topP,int timeout,
+// custom headers that can be added from user input
+List<RequestHeader>customHeaders){}


### PR DESCRIPTION
Added support for custom headers for each request.
Note: For headers with same key, custom header will take precedence and any existing value will be overridden. This includes some implementation auth keys that are passed for many inferences