### PR TITLE
[update] text and vision connection parameter to remove default value of topP

### DIFF
--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/parameters/TextGenerationConnectionParameters.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/parameters/TextGenerationConnectionParameters.java
@@ -4,6 +4,7 @@ import org.mule.runtime.api.meta.ExpressionSupport;
 import org.mule.runtime.extension.api.annotation.Expression;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
+import org.mule.runtime.extension.api.annotation.param.display.Example;
 import org.mule.runtime.extension.api.annotation.param.display.Placement;
 import org.mule.runtime.extension.api.annotation.param.display.Summary;
 
@@ -34,9 +35,10 @@ public class TextGenerationConnectionParameters extends BaseConnectionParameters
    */
   @Parameter
   @Expression(ExpressionSupport.SUPPORTED)
-  @Optional(defaultValue = "0.9")
+  @Optional
   @Placement(order = 5)
   @Summary("Controls diversity by limiting choices to the most probable options.")
+  @Example("0.9")
   private Number topP;
 
   public Number getMaxTokens() {

--- a/src/main/java/com/mulesoft/connectors/inference/internal/connection/parameters/VisionConnectionParameters.java
+++ b/src/main/java/com/mulesoft/connectors/inference/internal/connection/parameters/VisionConnectionParameters.java
@@ -4,6 +4,7 @@ import org.mule.runtime.api.meta.ExpressionSupport;
 import org.mule.runtime.extension.api.annotation.Expression;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
+import org.mule.runtime.extension.api.annotation.param.display.Example;
 import org.mule.runtime.extension.api.annotation.param.display.Placement;
 import org.mule.runtime.extension.api.annotation.param.display.Summary;
 
@@ -34,9 +35,10 @@ public class VisionConnectionParameters extends BaseConnectionParameters {
    */
   @Parameter
   @Expression(ExpressionSupport.SUPPORTED)
-  @Optional(defaultValue = "0.9")
+  @Optional
   @Placement(order = 4)
   @Summary("Controls diversity by limiting choices to the most probable options.")
+  @Example("0.9")
   private Number topP;
 
   public Number getMaxTokens() {


### PR DESCRIPTION
Claude new model support either topP or temperature and its recommended to use the temperature over topP as mentioned in the [official documentation](https://docs.claude.com/en/api/messages#body-top-p).